### PR TITLE
have the logo link to the ember homepage (like it used to)

### DIFF
--- a/source/_header.html.erb
+++ b/source/_header.html.erb
@@ -8,7 +8,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-   <a class="navbar-brand" href="/"><img src="/images/logos/ember-logo.svg" alt="home" /></a>
+   <a class="navbar-brand" href="https://emberjs.com"><img src="/images/logos/ember-logo.svg" alt="home" /></a>
   </div>
   <div class="collapse navbar-collapse" id="navbar-collapse">
    <ul class="nav navbar-nav">


### PR DESCRIPTION
This is just a tiny oversight when moving to the blog subdomain 👍 this will bring it in line with the behaviour of all other subprojects (guides, deprecations etc.) 