### PR TITLE
Fix typos in 3.8 release announcement

### DIFF
--- a/source/2019-02-27-ember-3-8-released.md
+++ b/source/2019-02-27-ember-3-8-released.md
@@ -1,11 +1,11 @@
 ---
 title: Ember 3.8 Released
 author: Melanie Sumner, Kenneth Larsen, Anne-Greeth van Herwijnen
-tags: Releases, 2018, 3, 3.8
+tags: Releases, 2019, 3, 3.8
 responsive: true
 ---
 
-Today the Ember project is releasing version 3.8 of Ember.js, Ember Data, and Ember CLI. This release kicks off the 3.8 beta cycle for all sub-projects. We encourage our community (especially addon authors) to help test these beta builds and report any bugs before they are published as a final release in six weeks' time. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
+Today the Ember project is releasing version 3.8 of Ember.js, Ember Data, and Ember CLI. This release kicks off the 3.9 beta cycle for all sub-projects. We encourage our community (especially addon authors) to help test these beta builds and report any bugs before they are published as a final release in six weeks' time. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
 
 You can read more about our general release process here:
 


### PR DESCRIPTION

## What it does
Fixes two typos:
 - tag for the year `2018 ➡️2019`
 - next version `3.8 ➡️3.9`

## Related Issue(s)
I didn't open an issue for these typos. 