### PR TITLE
Fixes code sample present in 3.10 release blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ installing dependencies.
 
 ``` sh
 git clone https://github.com/ember-learn/ember-blog.git
-cd website
+cd ember-blog
 bundle
 bundle exec middleman
 ```

--- a/source/2019-05-21-ember-3-10-released.md
+++ b/source/2019-05-21-ember-3-10-released.md
@@ -83,7 +83,7 @@ Previously, you were only able to invoke built-ins in your template using the cl
 ```hbs
 {{input type="text" value="Katie Gengler"}}
 
-{{link-to "photos.edit" photo}}
+{{link-to "Edit Photo" "photos.edit" photo}}
 
 {{textarea value=postComment cols="20" rows="6"}}
 ```
@@ -94,7 +94,9 @@ With Ember 3.10 and higher, you may alternatively use the angle bracket invocati
 <Input @type="text" @value="Katie Gengler" />
 
 {{! link-to with a single model }}
-<LinkTo @route="photos.edit" @model={{photo}} />
+<LinkTo @route="photos.edit" @model={{photo}}>
+  Edit Photo
+</LinkTo>
 
 {{! link-to with several models }}
 <LinkTo @route="photos.edit" @models={{array photo anotherPhoto}} />


### PR DESCRIPTION
When reading the RFC, it seems, we don't support inline invocation of `<LinkTo>` component. So, mentioning a similar pattern in the example may be misleading.

So, this PR fixes the code sample present in the "Angle Bracket Invocation for Nested Components" section of [3.10 release blog](https://blog.emberjs.com/2019/05/21/ember-3-10-released.html).
