### PR TITLE
Add Stale app to repo

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,22 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+
+# Issues with these labels will never be considered stale
+# exemptLabels:
+#  - pinned
+#  - security
+
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+  
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
## What it does
See: https://probot.github.io/apps/stale/. I added the Stale app to ember-blog and ember-website (these are the two repos that I have the most context on). I used the defaults from the Stale website. 

Note: Stale bumps issues and pull requests.

Tagging @jenweber cause we talked about it at the meeting, and @hakilebara based on his interests re: Ember-Learn Open Pull Requests Statistics. I think that this bot could really help us with keeping the "backlog" up to date, even if it's a #wontfix. I will also share in the Learning Channel.

Also added to ember-website: https://github.com/ember-learn/ember-website/pull/359