### PR TITLE
Add 'Version 3.x' tag to 3.x series posts.

### DIFF
--- a/source/2018-07-02-ember-3-2-released.md
+++ b/source/2018-07-02-ember-3-2-released.md
@@ -1,7 +1,7 @@
 ---
 title: Ember 3.2 Released
 author: Robert Jackson, Melanie Sumner & Kenneth Larsen
-tags: Releases, 2018, 3, 3.2
+tags: Releases, 2018, Version 3.x, 3, 3.2
 responsive: true
 alias : "blog/2018/06/29/ember-3-2-released.html"
 ---

--- a/source/2018-07-16-ember-3-3-released.md
+++ b/source/2018-07-16-ember-3-3-released.md
@@ -1,7 +1,7 @@
 ---
 title: Ember 3.3 Released
 author: Melanie Sumner, Brendan McLoughlin, and Alex Navasardyan
-tags: Releases, 2018, 3, 3.3
+tags: Releases, 2018, Version 3.x, 3, 3.3
 responsive: true
 ---
 

--- a/source/2018-10-07-ember-3-4-released.md
+++ b/source/2018-10-07-ember-3-4-released.md
@@ -1,7 +1,7 @@
 ---
 title: Ember 3.4 Released
 author: Melanie Sumner, Kenneth Larsen, David Baker, Jessica Jordan
-tags: Releases, 2018, 3, 3.4
+tags: Releases, 2018, Version 3.x, 3, 3.4
 responsive: true
 ---
 

--- a/source/2018-10-15-ember-3-5-released.md
+++ b/source/2018-10-15-ember-3-5-released.md
@@ -1,7 +1,7 @@
 ---
 title: Ember 3.5 Released
 author: Melanie Sumner, Jen Weber, Chris Thoburn
-tags: Releases, 2018, 3, 3.5
+tags: Releases, 2018, Version 3.x, 3, 3.5
 responsive: true
 ---
 

--- a/source/2018-12-13-ember-3-6-released.md
+++ b/source/2018-12-13-ember-3-6-released.md
@@ -1,7 +1,7 @@
 ---
 title: Ember 3.6 Released
 author: Melanie Sumner, Kenneth Larsen, Chris Garrett
-tags: Releases, 2018, 3, 3.6
+tags: Releases, 2018, Version 3.x, 3, 3.6
 responsive: true
 ---
 

--- a/source/2019-01-07-ember-3-7.md
+++ b/source/2019-01-07-ember-3-7.md
@@ -1,7 +1,7 @@
 ---
 title: Ember 3.7 Released
 author: Melanie Sumner, Kenneth Larsen
-tags: Releases, 2019, 3, 3.7
+tags: Releases, 2019, Version 3.x, 3, 3.7
 responsive: true
 ---
 

--- a/source/2019-02-27-ember-3-8-released.md
+++ b/source/2019-02-27-ember-3-8-released.md
@@ -1,7 +1,7 @@
 ---
 title: Ember 3.8 Released
 author: Melanie Sumner, Kenneth Larsen, Anne-Greeth van Herwijnen
-tags: Releases, 2019, 3, 3.8
+tags: Releases, 2019, Version 3.x, 3, 3.8
 responsive: true
 ---
 

--- a/source/2019-04-10-ember-3-9-released.md
+++ b/source/2019-04-10-ember-3-9-released.md
@@ -1,7 +1,7 @@
 ---
 title: Ember 3.9 Released
 author: Kenneth Larsen
-tags: Releases, 2019, 3, 3.9
+tags: Releases, 2019, Version 3.x, 3, 3.9
 responsive: true
 ---
 

--- a/source/2019-05-21-ember-3-10-released.md
+++ b/source/2019-05-21-ember-3-10-released.md
@@ -1,7 +1,7 @@
 ---
 title: Ember 3.10 Released
 author: Kenneth Larsen, Jessica Jordan
-tags: Releases, 2019, 3, 3.10
+tags: Releases, 2019, Version 3.x, 3, 3.10
 responsive: true
 ---
 

--- a/source/2019-07-15-ember-3-11-released.md
+++ b/source/2019-07-15-ember-3-11-released.md
@@ -1,7 +1,7 @@
 ---
 title: Ember 3.11 Released
 author: Kenneth Larsen
-tags: Releases, 2019, 3, 3.11
+tags: Releases, 2019, Version 3.x, 3, 3.11
 responsive: true
 ---
 


### PR DESCRIPTION
## What it does

Makes the **Browse by Major Version** link to the 3.x series cover all the releases in the 3.x series.