### PR TITLE
Enable most markdownlint defaults

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,5 +3,6 @@
   "line-length": false,
   "no-duplicate-heading": false,
   "no-emphasis-as-heading": false,
-  "no-inline-html": false
+  "no-inline-html": false,
+  "no-trailing-punctuation": false
 }

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,12 +1,4 @@
 {
   "default": true,
   "line-length": false,
-  "blanks-around-headings": false,
-  "no-trailing-spaces": false,
-  "no-multiple-blanks": false,
-  "blanks-around-fences": false,
-  "no-emphasis-as-heading": false,
-  "ul-start-left": false,
-  "no-duplicate-heading": false,
-  "no-trailing-punctuation": false
 }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # Ember Website
+
 [![Build Status](https://travis-ci.org/ember-learn/ember-blog.svg?branch=master)](https://travis-ci.org/ember-learn/ember-blog)
 
 This repository contains the blog content for the [Ember.js public website](https://emberjs.com).
 
 Other parts of the public website are separate apps:
+
 - [The Website](https://github.com/ember-learn/ember-website)
 - [API Docs](https://github.com/ember-learn/ember-api-docs)
 - [Deprecations](https://github.com/ember-learn/deprecation-app)
@@ -22,8 +24,7 @@ to propose changes and iterate on ideas before investing time in coding.
 Some tips for working with git/GitHub can be found in
 [Making your first pull request](https://github.com/ember-learn/guides-source/blob/master/CONTRIBUTING.md#making-your-first-pull-request) in the Guides respository.
 
-To contribute to Ember Times, a blog newsletter with weekly updates from the Ember land, please refer to this [Contributing Guide](https://github.com/ember-learn/ember-blog/blob/master/source/CONTRIBUTING.md).
-
+To contribute to the Ember Times, a blog newsletter with weekly updates from the Ember land, please refer to this [Contributing Guide](https://github.com/ember-learn/ember-blog/blob/master/source/CONTRIBUTING.md).
 
 ## Running locally with Docker (recommended)
 
@@ -45,11 +46,13 @@ cd website
 docker-compose build
 docker-compose up
 ```
+
 Subsequent runs will be much faster once all the dependencies are installed.
 
 You can view the site locally at [http://localhost:4567](http://localhost:4567)
 
 ## Running locally with Ruby and Middleman
+
 If you are unable to use Docker as described above, here's how to get started
 installing dependencies.
 
@@ -70,17 +73,18 @@ If the `bundle` command fails to run, you may need to upgrade your Ruby version.
 You can use [RVM](https://rvm.io/) to install it:
 
 ``` sh
-$ curl -L https://get.rvm.io | bash -s stable
-$ rvm install $(cat .ruby-version)
-$ rvm use $(cat .ruby-version)
+curl -L https://get.rvm.io | bash -s stable
+rvm install $(cat .ruby-version)
+rvm use $(cat .ruby-version)
 ```
 
 ### Troubleshooting tips for Windows devs
 
 For Windows developers using [RubyInstaller](http://rubyinstaller.org/), you'll need to [download the DevKit](http://rubyinstaller.org/downloads) and install it using instructions:
-https://github.com/oneclick/rubyinstaller/wiki/Development-Kit
+<https://github.com/oneclick/rubyinstaller/wiki/Development-Kit>
 
 After you have a proper install, you can then run:
+
 ``` sh
 gem install bundler wdm tzinfo-data
 gem update listen middleman

--- a/source/2019-07-26-the-ember-times-issue-108.md
+++ b/source/2019-07-26-the-ember-times-issue-108.md
@@ -40,6 +40,9 @@ If you are in charge of hiring new people or if you have a new colleague in your
 
 If you have started a new job, this post is also for you! We encourage you to think about how you want to be trained and how you can contribute to your team's onboarding process.
 
+
+
+
 ---
 
 ## [EmberMap: {{on}} Modifier Tutorial 🔛](https://embermap.com/video/on-modifier-a-first-look)

--- a/source/2019-07-26-the-ember-times-issue-108.md
+++ b/source/2019-07-26-the-ember-times-issue-108.md
@@ -40,9 +40,6 @@ If you are in charge of hiring new people or if you have a new colleague in your
 
 If you have started a new job, this post is also for you! We encourage you to think about how you want to be trained and how you can contribute to your team's onboarding process.
 
-
-
-
 ---
 
 ## [EmberMap: {{on}} Modifier Tutorial 🔛](https://embermap.com/video/on-modifier-a-first-look)

--- a/source/CONTRIBUTING.md
+++ b/source/CONTRIBUTING.md
@@ -1,12 +1,11 @@
 # General
 
-The Ember blog is the official news outlet of the Ember Learning Core team.
-You can publish new posts by adding a markdown file (`.md`) to the `source/blog` directory.
-
+The Ember blog is the official news outlet of the Ember Learning Core team. You can publish new posts by adding a markdown file (`.md`) to the `source/blog` directory.
 
 ## Language Checking with Alex
 
 This project uses [Alex](https://github.com/wooorm/alex)
+
 - a wording linter for insensitive language - to make sure that new posts are as inviting and approachable to its readers as possible.
 
 The Travis CI process for this project will run `alex` on all new changes which have been made
@@ -20,17 +19,21 @@ npm install -g alex
 bash scripts/language-check.sh
 ```
 
+Or, you can download an [extension](https://github.com/get-alex/alex#integrations) for your editor.
+
 If you are consciously [overriding the Alex linter](https://github.com/get-alex/alex#control) you can add an annotation before the paragraph as shown below.
 
 From the example error message:
 
 Text:
-```
+
+```bash
 A pop up window will occur.
 ```
 
 Error Message:
-```
+
+```bash
 readme.md
   1:15-1:18  warning  `pop` may be insensitive, use `parent` instead  dad-mom  retext-equality
 
@@ -38,17 +41,31 @@ readme.md
 ```
 
 Add the keyword to the ignore
-```
+
+```bash
 <!--alex ignore dad-mom-->
 A pop up window will occur.
 ```
 
-# Ember Times
+## Markdownlint
+
+We are using [markdownlint](https://github.com/DavidAnson/markdownlint) for linting!
+
+We suggest downloading a [markdownlint extension](https://github.com/DavidAnson/markdownlint#related) for your editor, if available.
+
+You can also install markdownlint locally:
+
+```bash
+npm install -g markdownlint
+bash scripts/markdown-lint.sh
+```
+
+## Ember Times
 
 The Ember Times is a blog newsletter with weekly updates from the Ember land.
 It is part of the [Emberjs.com](https://emberjs.com/) website and managed by the Learning Team and friends.
 
-## Contributing
+### Contributing
 
 Anyone can become an Ember Times editor. The best way to start is to join [#support-ember-times](https://discordapp.com/channels/480462759797063690/485450546887786506) channel on [Ember Community Discord](https://discordapp.com/invite/zT3asNS). New blog posts are released every Friday.
 
@@ -62,14 +79,14 @@ The process to publish a new weekly post is as follows:
 The Reader's Questions section of the newsletter is usually answered by core team members, but anyone can give a helping hand. 
 The answers are posted on [discuss.emberjs.com](https://discuss.emberjs.com/) and linked back to the weekly blog post.
 
-## Writing Style Guide
+### Writing Style Guide
 
-* Use Title Case for section headings, when in doubt use https://titlecase.com/.
-* Please add an emoji at the end of your title, if you're having trouble finding an emoji use a search tool like https://emojipedia.org/.
-* In general, refer to people by their GitHub handle, e.g. `[@your_name_here](https://www.github.com/your_name_here)`. (If the person is mentioned more than one time in the same paragraph, feel free to deviate after one @ mention!]
-* We tend to refer to `Ember`, `Ember Data`, and `Ember CLI` as their name (versus the repo name) because we mention them so often. For most other repos, use the repo name e.g. `[machty/ember-concurrency](https://github.com/machty/ember-concurrency)`.
-* The word `addon` is usually denoted as lowercase and as a single word.
-* Add your name to the author list at the bottom of the Times when submitting a PR for the week.
+- Use Title Case for section headings, when in doubt use https://titlecase.com/.
+- Please add an emoji at the end of your title, if you're having trouble finding an emoji use a search tool like https://emojipedia.org/.
+- In general, refer to people by their GitHub handle, e.g. `[@your_name_here](https://www.github.com/your_name_here)`. (If the person is mentioned more than one time in the same paragraph, feel free to deviate after one @ mention!]
+- We tend to refer to `Ember`, `Ember Data`, and `Ember CLI` as their name (versus the repo name) because we mention them so often. For most other repos, use the repo name e.g. `[machty/ember-concurrency](https://github.com/machty/ember-concurrency)`.
+- The word `addon` is usually denoted as lowercase and as a single word.
+- Add your name to the author list at the bottom of the Times when submitting a PR for the week.
 
 ### Goodbits
 
@@ -114,7 +131,7 @@ Add your section to the template. You'll see useful notes in the blank sections:
 
 - Use `git` to add your file and commit changes:
 
-``` 
+```bash
 git add .
 
 git commit -m "you-commit-message-here"

--- a/source/CONTRIBUTING.md
+++ b/source/CONTRIBUTING.md
@@ -51,14 +51,7 @@ A pop up window will occur.
 
 We are using [markdownlint](https://github.com/DavidAnson/markdownlint) for linting!
 
-We suggest downloading a [markdownlint extension](https://github.com/DavidAnson/markdownlint#related) for your editor, if available.
-
-You can also install markdownlint locally:
-
-```bash
-npm install -g markdownlint
-bash scripts/markdown-lint.sh
-```
+We suggest downloading a [markdownlint extension](https://github.com/DavidAnson/markdownlint#related) for your editor to see errors in real-time, if available.
 
 ## Ember Times
 

--- a/source/emberblog-template.md
+++ b/source/emberblog-template.md
@@ -16,7 +16,10 @@ You can read more about our general release process here:
 
 ---
 
-zzz
+zzzsdfsfsfsfsfs
+# test
+# test2
+sdfas
 
 
 

--- a/source/emberblog-template.md
+++ b/source/emberblog-template.md
@@ -16,6 +16,10 @@ You can read more about our general release process here:
 
 ---
 
+zzz
+
+
+
 ## Ember.js
 
 Ember.js is the core framework for building ambitious web applications.

--- a/source/emberblog-template.md
+++ b/source/emberblog-template.md
@@ -16,18 +16,12 @@ You can read more about our general release process here:
 
 ---
 
-zzzsdfsfsfsfsfs
-# test
-# test2
-sdfas
-
-
-
 ## Ember.js
 
 Ember.js is the core framework for building ambitious web applications.
 
 ### Changes in Ember.js VER
+
 Ember.js VER is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There is COUNT (#) new feature, COUNT (#) deprecations, and COUNT (#) bugfixes in this version.
 
 #### New Features (2)
@@ -35,7 +29,6 @@ Ember.js VER is an incremental, backwards compatible release of Ember with bugfi
 First new feature (1 of 2)
 
 Second new feature (2 of 2)
-
 
 #### Deprecations (0)
 
@@ -60,7 +53,6 @@ No new features introduced in Ember Data VER.
 #### Deprecations (0)
 
 No new deprecations introduced in Ember Data VER.
-
 
 For more details on changes in Ember Data VER, please review the
 [Ember Data VER.0 release page](https://github.com/emberjs/data/releases/tag/vVER.0).
@@ -87,7 +79,6 @@ While it is recommended to keep Ember CLI versions in sync with Ember and Ember 
 ### Changes in Ember CLI VER
 
 #### New Features (X)
-
 
 #### Deprecations (X)
 

--- a/source/embertimes-template.md
+++ b/source/embertimes-template.md
@@ -13,6 +13,7 @@ responsive: true
 ---
 
 ## [Section Title in Title Case 🐹](#section-url)
+
 <change section title emoji>
 <consider adding some bold to your paragraph>
   
@@ -22,6 +23,7 @@ responsive: true
 ---
 
 ## [Section Title in Title Case 🐹](#section-url)
+
 <change section title emoji>
 <consider adding some bold to your paragraph>
   
@@ -31,6 +33,7 @@ responsive: true
 ---
 
 ## [Section Title in Title Case 🐹](#section-url)
+
 <change section title emoji>
 <consider adding some bold to your paragraph>
   
@@ -40,6 +43,7 @@ responsive: true
 ---
 
 ## [Section Title in Title Case 🐹](#section-url)
+
 <change section title emoji>
 <consider adding some bold to your paragraph>
   
@@ -49,6 +53,7 @@ responsive: true
 ---
 
 ## [Section Title in Title Case 🐹](#section-url)
+
 <change section title emoji>
 <consider adding some bold to your paragraph>
   
@@ -58,6 +63,7 @@ responsive: true
 ---
 
 ## [Section Title in Title Case 🐹](#section-url)
+
 <change section title emoji>
 <consider adding some bold to your paragraph>
   
@@ -67,6 +73,7 @@ responsive: true
 ---
 
 ## [Section Title in Title Case 🐹](#section-url)
+
 <change section title emoji>
 <consider adding some bold to your paragraph>
   
@@ -76,6 +83,7 @@ responsive: true
 ---
 
 ## [Section Title in Title Case 🐹](#section-url)
+
 <change section title emoji>
 <consider adding some bold to your paragraph>
   
@@ -85,6 +93,7 @@ responsive: true
 ---
 
 ## [Section Title in Title Case 🐹](#section-url)
+
 <change section title emoji>
 <consider adding some bold to your paragraph>
   


### PR DESCRIPTION
## What it does

- Enable most markdownlint defaults
  - Reference: https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md
- Add markdownlint to CONTRIBUTING

## Related Issue(s)
Closes: https://github.com/ember-learn/ember-blog/issues/213
Follow-on to: https://github.com/ember-learn/ember-blog/pull/211