### PR TITLE
fixed globing patter to lint all markdown file in source folder

### DIFF
--- a/scripts/language-check.sh
+++ b/scripts/language-check.sh
@@ -3,5 +3,5 @@ git fetch base
 BLOG_HAS_CHANGES=$(git diff --name-status base/master source/2*)
 if [[ $BLOG_HAS_CHANGES ]]
   then
-    alex $(git diff --name-status base/master source/2* | sed s/^..//)
+    alex $(git diff --name-status base/master source/*.md | sed s/^..//)
 fi

--- a/scripts/markdown-lint.sh
+++ b/scripts/markdown-lint.sh
@@ -3,5 +3,5 @@ git fetch base
 BLOG_HAS_CHANGES=$(git diff --name-status base/master source/2*)
 if [[ $BLOG_HAS_CHANGES ]]
   then
-    markdownlint $(git diff --name-status base/master source/2* | sed s/^..//)
+    markdownlint $(git diff --name-status base/master source/*.md | sed s/^..//)
 fi


### PR DESCRIPTION
Very minor change. I noticed that globing patter for linters is only targeting anything in source folder that starts with number 2. It might be better to just target all markdown file. @amyrlam what do you think?