### PR TITLE
Fix a few markdown links in octane release post

### DIFF
--- a/source/2019-08-15-octane-release-plan.md
+++ b/source/2019-08-15-octane-release-plan.md
@@ -172,7 +172,7 @@ There is also `did-update` and `will-destroy`, which behave as you'd expect.
 
 **Modifiers work everywhere**. They work inside of classic components, inside of a route's templates, and inside of template-only components.
 
-One final thing: if you find yourself writing the same `did-insert` code in multiple places, you can extract the code into a *custom modifier*, which can even be packaged into addons. One cool example of a *custom modifier* that's already on npm is `[ember-did-resize-modifer](https://github.com/gmurphey/ember-did-resize-modifier)`, which allows you to attach custom logic to an element, whenever it changes size.
+One final thing: if you find yourself writing the same `did-insert` code in multiple places, you can extract the code into a *custom modifier*, which can even be packaged into addons. One cool example of a *custom modifier* that's already on npm is [`ember-did-resize-modifer`](https://github.com/gmurphey/ember-did-resize-modifier), which allows you to attach custom logic to an element, whenever it changes size.
 
 ```handlebars
 <div {{did-resize this.onResize}}>

--- a/source/2019-08-15-octane-release-plan.md
+++ b/source/2019-08-15-octane-release-plan.md
@@ -202,7 +202,7 @@ For more details, see the [API docs for on](https://api.emberjs.com/ember/3.12/c
 
 In classic Ember, you can refer to properties on a component as `{{propertyName}}`. This was ambiguous with helpers and components, and was deprecated in [RFC 308](https://emberjs.github.io/rfcs/0308-deprecate-property-lookup-fallback.html).
 
-No matter what kind of component you're using, you should start using `this` to refer to component properties in new code. The `[no-implicit-this](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-implicit-this.md)` template lint can help you avoid using this deprecated pattern by accident.
+No matter what kind of component you're using, you should start using `this` to refer to component properties in new code. The [`no-implicit-this`](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-implicit-this.md) template lint can help you avoid using this deprecated pattern by accident.
 
 Ember 3.14 will finalize a codemod that uses dynamic information from booting up your app to automatically insert `this` where needed. We recommend waiting for this codemod to be finalized before attempting to mass-migrate your codebase. 
 


### PR DESCRIPTION
<!--- Make sure to add a descriptive title in the field above! E.g. "Fixes the header title color on the homepage"  -->

## What it does
A few markdown links had incorrect formatting

<!--- Tell us what this fix does in a few sentences. E.g. "This updates the header title's font color to Ember Orange." -->

## Related Issue(s)
<!--- Please provide the issue(s) to which this pull request relates to or which issue it closes. E.g. "Closes #1234" -->

## Sources
<!-- Optional. If applicable be sure to add any screenshots or screen recordings of your work for your reviewers here -->
