### PR TITLE
fixed markdown link

### DIFF
--- a/source/2019-08-15-octane-release-plan.md
+++ b/source/2019-08-15-octane-release-plan.md
@@ -202,7 +202,7 @@ For more details, see the [API docs for on](https://api.emberjs.com/ember/3.12/c
 
 In classic Ember, you can refer to properties on a component as `{{propertyName}}`. This was ambiguous with helpers and components, and was deprecated in [RFC 308](https://emberjs.github.io/rfcs/0308-deprecate-property-lookup-fallback.html).
 
-No matter what kind of component you're using, you should start using `this` to refer to component properties in new code. The [`no-implicit-this`](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-implicit-this.md) template lint can help you avoid using this deprecated pattern by accident.
+No matter what kind of component you're using, you should start using `this` to refer to component properties in new code. The `no-implicit-this` [template lint rule](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-implicit-this.md) can help you avoid using this deprecated pattern by accident.
 
 Ember 3.14 will finalize a codemod that uses dynamic information from booting up your app to automatically insert `this` where needed. We recommend waiting for this codemod to be finalized before attempting to mass-migrate your codebase. 
 


### PR DESCRIPTION
## What it does

Putting real anchors in markdown source code snippets with backtics has limited
support which wasn't rendered correctly on the blog output. This moves
the link out of the code and just links the text beside it.

## Before

![Screen Shot 2019-08-16 at 1 56 32 PM](https://user-images.githubusercontent.com/51207/63187757-a96c0200-c02d-11e9-88e0-7bbd387364fd.png)

## After

![Screen Shot 2019-08-16 at 1 58 19 PM](https://user-images.githubusercontent.com/51207/63187771-b12ba680-c02d-11e9-82c7-1ba9bac5d75e.png)


