### PR TITLE
Fix optional feature command in Octane post

### DIFF
--- a/source/2019-08-15-octane-release-plan.md
+++ b/source/2019-08-15-octane-release-plan.md
@@ -93,7 +93,7 @@ Alternatively, you could eliminate any references to the implicit component by r
 When done, you can opt in to the new behavior:
 
 ```sh
-ember feature:enable template-only-glimmer-component
+ember feature:enable template-only-glimmer-components
 ```
 
 ### Glimmer Component Base Class


### PR DESCRIPTION
## What it does
The `template-only-glimmer-components` optional feature setting ends with `components` (plural) instead of `component` (singular): https://github.com/emberjs/ember-optional-features/blob/8d18f5f04e75502f193a95d3ad55eb726b9fda67/features/template-only-glimmer-components.js#L113

## Related Issue(s)
None

## Sources
https://github.com/emberjs/ember-optional-features/blob/8d18f5f04e75502f193a95d3ad55eb726b9fda67/features/template-only-glimmer-components.js
