### PR TITLE
Fixed feed URL in the layout template.

### DIFF
--- a/source/layout.erb
+++ b/source/layout.erb
@@ -24,7 +24,7 @@
     <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet" />
     <!--[if lte IE 7 ]><%= stylesheet_link_tag "fonts/fontello-ie7" %><![endif]-->
     <%= stylesheet_link_tag "site" %>
-    <link href="/blog/feed.xml" rel="alternate" type="application/atom+xml" title="Ember.js - Blog" />
+    <link href="/feed.xml" rel="alternate" type="application/atom+xml" title="Ember.js - Blog" />
     <% if current_page.data.no_index.eql? true %>
       <meta name="robots" content="noindex">
     <% end %>


### PR DESCRIPTION
## What it does
Fixes broken RSS feed `<link>` in the layout template.

## Related Issue(s)
Since the feed URL changed in #11  there is still a dead link to the old URL. 

## Sources
In the `<head>` currently:

```html
<link href="/blog/feed.xml" rel="alternate" type="application/atom+xml" title="Ember.js - Blog" />
```
[https://blog.emberjs.com/blog/feed.xml](https://blog.emberjs.com/blog/feed.xml) => 404 🚫 
[https://blog.emberjs.com/feed.xml](https://blog.emberjs.com/feed.xml) =>  200 ✅ 
