### PR TITLE
ci(markdown): re-enable markdown linting (see #284)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ before_install:
 script:
 - npm install alex markdownlint-cli --global
 - bash scripts/language-check.sh
-# - bash scripts/markdown-lint.sh
+- bash scripts/markdown-lint.sh
 - bundle exec middleman build


### PR DESCRIPTION
<!--- Make sure to add a descriptive title in the field above! E.g. "Fixes the header title color on the homepage"  -->

## What it does
<!--- Tell us what this fix does in a few sentences. E.g. "This updates the header title's font color to Ember Orange." -->

This reenables the markdown linting step in CI after merging #284

## Related Issue(s)
<!--- Please provide the issue(s) to which this pull request relates to or which issue it closes. E.g. "Closes #1234" -->

## Sources
<!-- Optional. If applicable be sure to add any screenshots or screen recordings of your work for your reviewers here -->
