### PR TITLE
Use direct links to Octane guide

### DIFF
--- a/source/2019-09-25-ember-3-13-released.md
+++ b/source/2019-09-25-ember-3-13-released.md
@@ -19,9 +19,9 @@ So why is this a preview and not the final Octane release?
 
 A big part of Octane is about delivering an excellent developer experience, whether you are a beginner or a power user. While these APIs are stable, not all Octane features are compatible with popular addons yet. We are also still updating documentation, and important tools like the Ember Inspector do not yet work with some Octane features. Octane is not complete until these supporting pieces are in place.
 
-Then, when Ember 3.14 arrives, Octane will be the recommended way to use Ember and new apps will have Octane's optional features enabled by default. The guides and tutorials will show Octane examples, and codemods will be available to help users migrate to Octane. Feel free to take a look at the [current draft](https://emberjs.com/editions/octane) of these learning resources, which are deployed to a temporary URL.
+Then, when Ember 3.14 arrives, Octane will be the recommended way to use Ember and new apps will have Octane's optional features enabled by default. The guides and tutorials will show Octane examples, and codemods will be available to help users migrate to Octane. Feel free to take a look at the [current draft](https://octane-guides-preview.emberjs.com/release/) of these learning resources, which are deployed to a temporary URL.
 
-The Ember tutorial has already been completely rewritten for Octane, and the easiest way to understand the big picture of Octane, especially if you're already an experienced Ember developer, is to [work through the new tutorial](https://emberjs.com/editions/octane).
+The Ember tutorial has already been completely rewritten for Octane, and the easiest way to understand the big picture of Octane, especially if you're already an experienced Ember developer, is to [work through the new tutorial](https://octane-guides-preview.emberjs.com/release/tutorial/00-part-1/).
 
 ---
 


### PR DESCRIPTION
I'd prefer it if we could link directly to the Octane guides. I understand that this was an intentional change because the URL is temporary, but given the nature of the blog post I would rather optimize for helping people find the relevant thing _now_ rather than optimize for having the link work for eternity. I'm happy to open an issue to track and update (or remove) the link when we do eventually take down the preview site.