### PR TITLE
Add additional Octane enable steps to 3.13 release post

### DIFF
--- a/source/2019-09-25-ember-3-13-released.md
+++ b/source/2019-09-25-ember-3-13-released.md
@@ -27,29 +27,29 @@ The Ember tutorial has already been completely rewritten for Octane, and the eas
 
 You can try out the Octane preview by performing a few steps:
 
-1) Add the following packages if they aren't already present at this version:
+1. Add the following packages if they aren't already present at this version:
 
-```js
-npm install --save-dev @ember/edition-utils@^1.1.1
-npm install --save-dev @glimmer/component@^0.14.0-alpha.13
-```
+    ```js
+    npm install --save-dev @ember/edition-utils@^1.1.1
+    npm install --save-dev @glimmer/component@^0.14.0-alpha.13
+    ```
 
-2) Disable legacy behavior by setting the following feature flags:
+1. Disable legacy behavior by setting the following feature flags:
 
-```bash
-ember feature:disable jquery-integration
-ember feature:enable template-only-glimmer-components
-ember feature:disable application-template-wrapper
-```
+    ```bash
+    ember feature:disable jquery-integration
+    ember feature:enable template-only-glimmer-components
+    ember feature:disable application-template-wrapper
+    ```
 
-3) Specify the Octane edition in `.ember-cli.js` by adding the following lines to the beginning of the file:
+1. Specify the Octane edition in `.ember-cli.js` by adding the following lines to the beginning of the file:
 
-```js
-// .ember-cli.js
-const { setEdition } = require('@ember/edition-utils');
+    ```js
+    // .ember-cli.js
+    const { setEdition } = require('@ember/edition-utils');
 
-setEdition('octane');
-```
+    setEdition('octane');
+    ```
 
 If you have an `.ember-cli` file instead of an `.ember-cli.js` file, you can convert it by renaming it to `.ember-cli.js`, then taking the existing JSON object and assigning it to `module.exports`. For example, if you have an `.ember-cli` file with:
 

--- a/source/2019-09-25-ember-3-13-released.md
+++ b/source/2019-09-25-ember-3-13-released.md
@@ -165,7 +165,8 @@ Ember CLI is the command line interface for managing and packaging Ember.js appl
 
 ### Upgrading Ember CLI
 
-You may upgrade Ember CLI using the ember-cli-update project:
+<!--alex ignore easy-->
+You may upgrade Ember CLI easily using the ember-cli-update project:
 
 ```bash
 npm install -g ember-cli-update

--- a/source/2019-09-25-ember-3-13-released.md
+++ b/source/2019-09-25-ember-3-13-released.md
@@ -27,29 +27,29 @@ The Ember tutorial has already been completely rewritten for Octane, and the eas
 
 You can try out the Octane preview by performing a few steps:
 
-1. Add the following packages if they aren't already present at this version:
+Add the following packages if they aren't already present at this version:
 
-    ```js
-    npm install --save-dev @ember/edition-utils@^1.1.1
-    npm install --save-dev @glimmer/component@^0.14.0-alpha.13
-    ```
+```js
+npm install --save-dev @ember/edition-utils@^1.1.1
+npm install --save-dev @glimmer/component@^0.14.0-alpha.13
+```
 
-1. Disable legacy behavior by setting the following feature flags:
+Disable legacy behavior by setting the following feature flags:
 
-    ```bash
-    ember feature:disable jquery-integration
-    ember feature:enable template-only-glimmer-components
-    ember feature:disable application-template-wrapper
-    ```
+```bash
+ember feature:disable jquery-integration
+ember feature:enable template-only-glimmer-components
+ember feature:disable application-template-wrapper
+```
 
-1. Specify the Octane edition in `.ember-cli.js` by adding the following lines to the beginning of the file:
+Specify the Octane edition in `.ember-cli.js` by adding the following lines to the beginning of the file:
 
-    ```js
-    // .ember-cli.js
-    const { setEdition } = require('@ember/edition-utils');
+```js
+// .ember-cli.js
+const { setEdition } = require('@ember/edition-utils');
 
-    setEdition('octane');
-    ```
+setEdition('octane');
+```
 
 If you have an `.ember-cli` file instead of an `.ember-cli.js` file, you can convert it by renaming it to `.ember-cli.js`, then taking the existing JSON object and assigning it to `module.exports`. For example, if you have an `.ember-cli` file with:
 

--- a/source/2019-09-25-ember-3-13-released.md
+++ b/source/2019-09-25-ember-3-13-released.md
@@ -25,7 +25,16 @@ The Ember tutorial has already been completely rewritten for Octane, and the eas
 
 ---
 
-You can try out the Octane preview by disabling legacy behavior and specifying the Octane edition in `.ember-cli.js`.
+You can try out the Octane preview by performing a few steps:
+
+1) Add the following packages if they aren't already present at this version:
+
+```js
+npm install --save-dev @ember/edition-utils@^1.1.1
+npm install --save-dev @glimmer/component@^0.14.0-alpha.13
+```
+
+2) Disable legacy behavior by setting the following feature flags:
 
 ```bash
 ember feature:disable jquery-integration
@@ -33,9 +42,7 @@ ember feature:enable template-only-glimmer-components
 ember feature:disable application-template-wrapper
 ```
 
-If you need more information on how to migrate away from these legacy features, check out the [Octane release plan](https://blog.emberjs.com/2019/08/15/octane-release-plan.html) blog post.
-
-To opt in to the Octane preview, add the following lines to the beginning of `.ember-cli.js`.
+3) Specify the Octane edition in `.ember-cli.js` by adding the following lines to the beginning of the file:
 
 ```js
 // .ember-cli.js
@@ -43,6 +50,26 @@ const { setEdition } = require('@ember/edition-utils');
 
 setEdition('octane');
 ```
+
+If you have an `.ember-cli` file instead of an `.ember-cli.js` file, you can convert it by renaming it to `.ember-cli.js`, then taking the existing JSON object and assigning it to `module.exports`. For example, if you have an `.ember-cli` file with:
+
+```json
+// .ember-cli
+{
+  "disableAnalytics": false
+}
+```
+
+The equivalent `.ember-cli.js` file would be:
+
+```js
+// .ember-cli.js
+module.exports = {
+  "disableAnalytics": false
+}
+```
+
+If you need more information on how to migrate away from these legacy features, check out the [Octane release plan](https://blog.emberjs.com/2019/08/15/octane-release-plan.html) blog post.
 
 ---
 

--- a/source/2019-09-25-ember-3-13-released.md
+++ b/source/2019-09-25-ember-3-13-released.md
@@ -165,7 +165,7 @@ Ember CLI is the command line interface for managing and packaging Ember.js appl
 
 ### Upgrading Ember CLI
 
-You may upgrade Ember CLI easily using the ember-cli-update project:
+You may upgrade Ember CLI using the ember-cli-update project:
 
 ```bash
 npm install -g ember-cli-update


### PR DESCRIPTION
## What it does

Adds additional steps to the instructions for enabling the Octane preview in 3.13 stable. I've tested these on a new Ember 3.13 app and confirmed they work.

In the current state:

- A new Ember 3.13 app has an `.ember-cli` file, and there aren't instructions in this post for how to convert it to an `.ember-cli.js` file.
- There aren't instructions for adding `@glimmer/component`, so Glimmer components don't work after enabling Octane.

An alternative approach would be to include instructions for running `npx @ember/octanify` to take care of some of these steps. However, it doesn't cover all the steps: there has not been a release of octanify since [my PR to add @glimmer/component](https://github.com/emberjs/ember-octanify/pull/2) was added. If we want to run octanify I'd be happy to take that approach in the post. But I think we need to update the blog post ASAP without waiting for an octanify release since the current instructions are incomplete.

## Related Issue(s)
n/a

## Sources

<img width="804" alt="Screen Shot 2019-10-08 at 8 44 42 AM" src="https://user-images.githubusercontent.com/15832198/66396510-e60e0700-e9a7-11e9-9a9f-6932066c7efa.png">
