### PR TITLE
Fixed missing left padding on medium sized screens

### DIFF
--- a/source/stylesheets/blog.css.scss
+++ b/source/stylesheets/blog.css.scss
@@ -87,6 +87,7 @@ body.blog.responsive {
       width: 75% !important;
       float: left !important;
       padding-right: 2em;
+      padding-left: 2em;
 
       @media screen and (max-width: $small-breakpoint) {
         width: 100% !important;


### PR DESCRIPTION
no issue

- when the browser window is between 768 and 1200px wide, the main content is squashed up against the left edge of the window
- added a 2em left margin at those sizes to match the spacing on right-hand side of the content

Before:
<img width="1149" alt="Screenshot 2019-10-21 at 18 06 32" src="https://user-images.githubusercontent.com/415/67226983-2ea8d400-f42e-11e9-9061-3582a9b537f6.png">

After:
<img width="1149" alt="Screenshot 2019-10-21 at 18 06 36" src="https://user-images.githubusercontent.com/415/67226990-35374b80-f42e-11e9-96cd-ea6a991c7a8b.png">
