### PR TITLE
Add "READMORE" to December 1st post

### DIFF
--- a/source/2019-12-01-countdown-to-the-new-year-ember-sortable.md
+++ b/source/2019-12-01-countdown-to-the-new-year-ember-sortable.md
@@ -12,6 +12,8 @@ responsive: true
 
 To kick things off, we're going to look at [ember-sortable](https://emberobserver.com/addons/ember-sortable). 
 
+READMORE
+
 ### What It Does
 
 The `ember-sortable` addon provides sortable UI primitives for Ember apps- this is super useful in the sense that teams don't have to reinvent this very common pattern every time they need it for their own applications! 

--- a/source/december-2019-blog-series-template.md
+++ b/source/december-2019-blog-series-template.md
@@ -8,17 +8,22 @@ assignees: ''
 ---
 
 ## Goal
+
 Write a short blog post for the December blog series that is similar to the [example post]( https://github.com/ember-learn/ember-blog/blob/be8f29ba0ae8b5367d1758b1a150c1b503812a77/source/2019-12-01-countdown-to-the-new-year-ember-sortable.md).
 
 ## Criteria
 
--  [ ] file name should 2019-12-DD-countdown-to-the-new-year-ADDON-NAME.md where DD is replaced with the day and ADDON-NAME is replaced with the hyphenated name of the addon
+- [ ] file name should 2019-12-DD-countdown-to-the-new-year-ADDON-NAME.md where DD is replaced with the day and ADDON-NAME is replaced with the hyphenated name of the addon
 - [ ] The opening sentence should be updated where COUNT is the sequential ordinal word. 
 
-```
-<b>This is the COUNT in our DecEmber series- <i>"Countdown to The New Year: 31 Days of 
-Ember Addons"</i>.  We plan to highlight a new addon each day until the new year, and 
-we hope you'll join us for the fun!</b>
+```markdown
+**This is the COUNT in our DecEmber series- <span style="font-style: italic;">"Countdown to The New Year: 31 Days of Ember Addons"</span>. We plan to highlight a new addon each day until the new year, and we hope you'll join us for the fun!**
+
+## Day COUNT
+
+To kick things off, we're going to look at [](). 
+
+READMORE
 ```
 
 - [ ] The first h2 should be "Day NUM" where NUM is the same as the DD in the date.


### PR DESCRIPTION
## What it does
* This way, the preview on the /blog URL is cut off at the end of the sentence.
* Also, Update template to have READMORE
* Rename template and move template to where other blog templates are

## Sources
WAS:
![image](https://user-images.githubusercontent.com/1372946/69982482-73be2c80-14e9-11ea-8faa-8a1f8aed29a7.png)

IS: 
![image](https://user-images.githubusercontent.com/1372946/69982855-4625b300-14ea-11ea-9b1d-e374198375b0.png)

Is minor, but in the past there was confusion by a `...` followed by "Read more`...`"