### PR TITLE
Add DecEmber tag

### DIFF
--- a/source/_sidebar.html.erb
+++ b/source/_sidebar.html.erb
@@ -68,6 +68,7 @@
   <h3 class="list-group-title" id="browse-subject">Browse by Subject</h3>
   <ul class="list-group" aria-labelledby="browse-subject">
     <li class="list-item"><a href="<%= tag_path 'Announcement'%>">Announcements</a></li>
+    <li class="list-item"><a href="<%= tag_path 'DecEmber'%>">DecEmber</a></li>
     <li class="list-item"><a href="<%= tag_path 'Ember CLI'%>">Ember CLI</a></li>
     <li class="list-item"><a href="<%= tag_path 'Ember Data'%>">Ember Data</a></li>
     <li class="list-item"><a href="<%= tag_path 'Newsletter'%>">Newsletter</a></li>


### PR DESCRIPTION
## What it does
* Adds DecEmber tag to RHS
* There is now a clickable `DecEmber` link of all posts: https://deploy-preview-416--ember-blog-legacy.netlify.com/tags/december.html (I can modify Monday's Ember Times tweet to include this, let me know) 
* Do you also want to have `Addons` be another tag? 

![image](https://user-images.githubusercontent.com/1372946/70368445-62fe1580-185f-11ea-8f57-59a0c01e0107.png)
