### PR TITLE
blog(cttny): remove year from filename to fix middleman build

### DIFF
--- a/source/2019-12-15-countdown-to-the-new-year-ember-test-selectors.md
+++ b/source/2019-12-15-countdown-to-the-new-year-ember-test-selectors.md
@@ -1,12 +1,12 @@
 ---
-title: Countdown to The New Year: Ember Test Selectors
+title: Countdown to The New Year - Ember Test Selectors
 author: Jessica Jordan
 tags: 2019, Addons, DecEmber, Testing
-alias: 2019/12/15/countdown-to-the-new-year-2019-ember-test-selectors
+alias: 2019/12/15/countdown-to-the-new-year-ember-test-selectors
 responsive: true
 ---
 
-**Our December series-"Countdown to The New Year: 31 Days of Ember Addons" aims to highlight a new addon each day until the new year, and we hope you enjoy hearing about addons that bring us joy as well!**
+**Our December series - "Countdown to The New Year: 31 Days of Ember Addons" aims to highlight a new addon each day until the new year, and we hope you enjoy hearing about addons that bring us joy as well!**
 
 ## Day 15
 


### PR DESCRIPTION
The middleman build currently fails after merging https://github.com/ember-learn/ember-blog/pull/381 - reproducing the issue locally, it seems that renaming the file to only include the year once seems to resolve the issue.
