### PR TITLE
Add Accessibility and Addons tags

### DIFF
--- a/source/2019-12-01-countdown-to-the-new-year-ember-sortable.md
+++ b/source/2019-12-01-countdown-to-the-new-year-ember-sortable.md
@@ -1,7 +1,7 @@
 ---
 title: Countdown to The New Year - Ember Sortable
 author: Melanie Sumner
-tags: 2019, Addons, DecEmber
+tags: 2019, Accessibility, Addons, DecEmber
 alias: 2019-12-01-countdown-to-the-new-year-ember-sortable.md
 responsive: true
 ---

--- a/source/2019-12-02-countdown-to-the-new-year-ember-cli-mirage.md
+++ b/source/2019-12-02-countdown-to-the-new-year-ember-cli-mirage.md
@@ -1,7 +1,7 @@
 ---
 title: Countdown to The New Year - Ember CLI Mirage
 author: Melanie Sumner
-tags: 2019, Addons, DecEmber
+tags: 2019, Addons, DecEmber, Testing
 alias: 2019-12-02-countdown-to-the-new-year-ember-cli-mirage.md
 responsive: true
 ---

--- a/source/2019-12-10-countdown-to-the-new-year-ember-a11y-testing.md
+++ b/source/2019-12-10-countdown-to-the-new-year-ember-a11y-testing.md
@@ -1,7 +1,7 @@
 ---
 title: Countdown to The New Year- Ember A11Y Testing
 author: Sivakumar Kailasam
-tags: 2019, Addons, DecEmber, A11y
+tags: 2019, Accessibility, Addons, DecEmber, Testing
 alias: 2019-12-10-countdown-to-the-new-year-ember-a11y-testing.md
 responsive: true
 ---

--- a/source/2019-12-11-countdown-to-the-new-year-ember-page-title.md
+++ b/source/2019-12-11-countdown-to-the-new-year-ember-page-title.md
@@ -1,7 +1,7 @@
 ---
 title: Countdown to The New Year - Ember Page Title
 author: Venus Ang
-tags: 2019, Addons, DecEmber
+tags: 2019, Accessibility, Addons, DecEmber
 alias: 2019-12-11-countdown-to-the-new-year-ember-page-title.md
 responsive: true
 ---

--- a/source/_sidebar.html.erb
+++ b/source/_sidebar.html.erb
@@ -68,6 +68,8 @@
   <h3 class="list-group-title" id="browse-subject">Browse by Subject</h3>
   <ul class="list-group" aria-labelledby="browse-subject">
     <li class="list-item"><a href="<%= tag_path 'Announcement'%>">Announcements</a></li>
+    <li class="list-item"><a href="<%= tag_path 'Announcement'%>">Accessibility</a></li>
+    <li class="list-item"><a href="<%= tag_path 'Announcement'%>">Addons</a></li>
     <li class="list-item"><a href="<%= tag_path 'DecEmber'%>">DecEmber</a></li>
     <li class="list-item"><a href="<%= tag_path 'Ember CLI'%>">Ember CLI</a></li>
     <li class="list-item"><a href="<%= tag_path 'Ember Data'%>">Ember Data</a></li>


### PR DESCRIPTION
## What it does
Add Accessibility and Addons tags (I went for `Accessbility` instead of `a11y`, let me know if think otherwise 
Also, update tags of some DecEmber posts

## Related Issue(s)
https://github.com/ember-learn/ember-blog/pull/435#issuecomment-565707779
https://github.com/ember-learn/ember-blog/pull/416

## Sources
IS: (see Netlify)
![image](https://user-images.githubusercontent.com/1372946/70940808-fd005380-1fff-11ea-9f07-a7952387d1eb.png)
