### PR TITLE
Prevent <!--alex enable wordhere--> from appearing

### DIFF
--- a/source/2017-04-05-emberconf-2017-state-of-the-union.md
+++ b/source/2017-04-05-emberconf-2017-state-of-the-union.md
@@ -471,5 +471,6 @@ It should also work in reverse: if you start with Glimmer and realize you actual
 
 This is the future we've always dreamed of for Ember: a complete, cohesive front-end stack for those who want it, with the ability to quickly pare it down if the need arises.
 
-We're not there quite yet, but it's an exciting goal to build toward and I think we've shown tangible progress already with Glimmer. I hope you are as excited about Ember and Glimmer as we are, and we can't wait to see all of the cool stuff you build with them!
 <!--alex enable savage just of-course obvious trap jesus easy clearly-->
+
+We're not there quite yet, but it's an exciting goal to build toward and I think we've shown tangible progress already with Glimmer. I hope you are as excited about Ember and Glimmer as we are, and we can't wait to see all of the cool stuff you build with them!

--- a/source/2018-11-30-the-emberjs-times-issue-75.md
+++ b/source/2018-11-30-the-emberjs-times-issue-75.md
@@ -132,6 +132,8 @@ Want to write for the Ember Times? Have a suggestion for next week's issue? Join
 
 Keep on top of what's been going on in Emberland this week by subscribing to our [e-mail newsletter](https://the-emberjs-times.ongoodbits.com/)! You can also find our posts on the [Ember blog](https://emberjs.com/blog/tags/newsletter.html).
 
+<!--alex enable just clearly-->
+
 ---
 
 
@@ -140,4 +142,3 @@ That's another wrap! ✨
 Be kind,
 
 Melanie Sumner, Chris Ng, Amy Lam, Alon Bukai, Kenneth Larsen, Jessica Jordan and the Learning Team
-<!--alex enable just clearly-->

--- a/source/2019-01-26-emberjs-native-class-update-2019-edition.md
+++ b/source/2019-01-26-emberjs-native-class-update-2019-edition.md
@@ -541,5 +541,7 @@ Generally, derived state like this is handled better by getters/setters, so this
 * [The Native Class Codemod (WIP)](https://github.com/scalvert/ember-es6-class-codemod)
 * [Ember Native Class ESLint Plugin](https://github.com/scalvert/eslint-plugin-ember-es6-class)
 
-And that's all folks! If you have more questions, join the [Ember Discord](https://www.emberjs.com/community/) and ask away, the `#e-decorators`, `#e-typescript`, `#st-native-classes`, and `#st-octane` channels are all great places to get some advice. Thanks for reading!
 <!--alex enable just easy-->
+
+And that's all folks! If you have more questions, join the [Ember Discord](https://www.emberjs.com/community/) and ask away, the `#e-decorators`, `#e-typescript`, `#st-native-classes`, and `#st-octane` channels are all great places to get some advice. Thanks for reading!
+


### PR DESCRIPTION
<!--- Make sure to add a descriptive title in the field above! E.g. "Fixes the header title color on the homepage"  -->

## What it does
<!--- Tell us what this fix does in a few sentences. E.g. "This updates the header title's font color to Ember Orange." -->

`alex` no longer appears on these pages
* https://deploy-preview-634--ember-blog-legacy.netlify.app/2018/11/30/the-emberjs-times-issue-75.html
* https://deploy-preview-634--ember-blog-legacy.netlify.app/2017/04/05/emberconf-2017-state-of-the-union.html
* https://deploy-preview-634--ember-blog-legacy.netlify.app/2019/01/26/emberjs-native-class-update-2019-edition.html

Was fine before, how I figured out what to do:
* https://deploy-preview-634--ember-blog-legacy.netlify.app/2019/08/16/the-ember-times-issue-111.html
* https://blog.emberjs.com/2020/04/10/the-ember-times-issue-143.html

I need to look at the alex code. It seems like if `alex enable` is at the bottom of the page, or not separated by line breaks, it appears mistakenly