### PR TITLE
Drop the featured Octane post

### DIFF
--- a/source/2019-12-20-octane-is-here.md
+++ b/source/2019-12-20-octane-is-here.md
@@ -1,7 +1,7 @@
 ---
 title: Octane is Here
 author: Yehuda Katz
-tags: Recent Posts, 2019, Announcement, Featured Announcement, Ember Octane
+tags: Recent Posts, 2019, Announcement, Ember Octane
 alias: 2019-12-20-octane-is-here.md
 responsive: true
 date: "2019-12-20 16:31:00 -0500"

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -9,7 +9,7 @@ per_page: 10
 
 <h1 class="text-left">News & Updates</h1>
 
-<% blog.tags['Featured Announcement'].sort_by(&:date).reverse.take(1).each_with_index do |article, i| %>
+<% (blog.tags['Featured Announcement'] || []).sort_by(&:date).reverse.take(1).each_with_index do |article, i| %>
 <article class="blog-post featured-announcement">
     <div class="blog-post-header">
       <h2 class="blog-post-title">Featured Post: <%= link_to article.title, article %> </h2>


### PR DESCRIPTION
Drop the feature "Octane is here" blog post. We added this functionality to make sure the main announcement wasn't buried by other content, but I think by now we're good. It has been featured since December.