### PR TITLE
(fix): Minor text correction

### DIFF
--- a/source/2020-06-19-the-ember-times-issue-153.md
+++ b/source/2020-06-19-the-ember-times-issue-153.md
@@ -84,8 +84,8 @@ A huge shout out to everyone who was involved in the Ember A11y Strike Team with
 - [Frédéric Soumaré (@hakilebara)](https://github.com/hakilebara),
 - [Benjamin JEGARD (@KamiKillertO)](https://github.com/KamiKillertO),
 - [Lenora Porter (@lenoraporter)](https://github.com/lenoraporter),
-- [Ricardo Mendes (@locks)](https://github.com/locks) and
-- [Mel Sumner (@MelSumner)](https://github.com/MelSumner)
+- [Ricardo Mendes (@locks)](https://github.com/locks)
+- [Mel Sumner (@MelSumner)](https://github.com/MelSumner) and
 - [Rob Jackson (@rwjblue)](https://github.com/rwjblue)
 
 💖💖💖💖💖💖


### PR DESCRIPTION
Fixes the "and" wording positioning under the a11y strike team member list.