### PR TITLE
fix disqus comments

### DIFF
--- a/source/layouts/blog.erb
+++ b/source/layouts/blog.erb
@@ -47,6 +47,10 @@
   <% else %>
     <div id="disqus_thread"></div>
     <script>
+      var pageUrl = 'https://emberjs.com/blog<%= current_page.url %>'
+      window.disqus_config = function () {
+        this.page.url = pageUrl;
+      };
       var disqus_shortname = 'emberblog';
       (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;


### PR DESCRIPTION
Thanks to @nickschot for finding this and providing the snippet to fix it 😂 🎉  (I am merely a conduit!) 

Essentially old disqus comments have not been loading since we moved the blog from https://emberjs.com/blog/ to https://blog.emberjs.com 🙃   this should fix it (and hopefully we can check it in the preview deployment 🤔 ) 