### PR TITLE
chore: Fix `the its` -> `its` grammar

### DIFF
--- a/source/2020-07-29-ember-3-20-released.md
+++ b/source/2020-07-29-ember-3-20-released.md
@@ -44,7 +44,7 @@ To use the helper, pass in a DOM element to target (`this.myDestinationElement` 
 
 This new public API behaves a little differently from the private API:
 
-- For the public API `{{in-element}}`, by default, the rendered content will replace all the content of the destination, effectively becoming the its `innerHTML`. If you want it to be appended instead of replacing the content, you can pass in `insertBefore=null`.
+- For the public API `{{in-element}}`, by default, the rendered content will replace all the content of the destination, effectively becoming its `innerHTML`. If you want it to be appended instead of replacing the content, you can pass in `insertBefore=null`.
 - In the private API `{{-in-element}}`, the rendered content was appended to any existing content in the destination.
 
 Developers should use the public API, `{{in-element}}`, and discontinue using `{{-in-element}}`.


### PR DESCRIPTION
<!--- Make sure to add a descriptive title in the field above! E.g. "Fixes the header title color on the homepage"  -->

## What it does
<!--- Tell us what this fix does in a few sentences. E.g. "This updates the header title's font color to Ember Orange." -->

## Related Issue(s)
<!--- Please provide the issue(s) to which this pull request relates to or which issue it closes. E.g. "Closes #1234" -->

## Sources
<!-- Optional. If applicable be sure to add any screenshots or screen recordings of your work for your reviewers here -->
