### PR TITLE
Update documentation to use `git switch` over `git update`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ Thank you for contributing to The Ember Times! Let us know if you can be a guest
     git fetch upstream
 
     # Switch to the current Ember Times branch
-    git checkout blog/embertimes-165
+    git switch blog/embertimes-165
     ```
 
 1. Open the Markdown file for the current blog issue: `source/2020-10-09-the-ember-times-issue-165.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ Thank you for contributing to The Ember Times! Let us know if you can be a guest
     git fetch upstream
 
     # Switch to the current Ember Times branch
-    git switch -t upstream/blog/embertimes-167
+    git switch -t upstream/blog/embertimes-165
     ```
 
 1. Open the Markdown file for the current blog issue: `source/2020-10-09-the-ember-times-issue-165.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ Thank you for contributing to The Ember Times! Let us know if you can be a guest
     git fetch upstream
 
     # Switch to the current Ember Times branch
-    git switch blog/embertimes-165
+    git switch -t upstream/blog/embertimes-167
     ```
 
 1. Open the Markdown file for the current blog issue: `source/2020-10-09-the-ember-times-issue-165.md`.

--- a/documentations/general.md
+++ b/documentations/general.md
@@ -56,7 +56,7 @@ A typical Git forking workflow can be used to contribute:
 
 For example, switch to this branch for issue 92: `blog/embertimes-92`
 
-`git switch -t upstream/blog/embertimes-167`
+`git switch -t upstream/blog/embertimes-165`
 
 - Find the latest blog issue template at `source/YYYY-MM-DD-the-ember-times-issue-#.md`
 

--- a/documentations/general.md
+++ b/documentations/general.md
@@ -56,7 +56,7 @@ A typical Git forking workflow can be used to contribute:
 
 For example, switch to this branch for issue 92: `blog/embertimes-92`
 
-`git switch blog/embertimes-92`
+`git switch -t upstream/blog/embertimes-167`
 
 - Find the latest blog issue template at `source/YYYY-MM-DD-the-ember-times-issue-#.md`
 

--- a/documentations/general.md
+++ b/documentations/general.md
@@ -56,7 +56,7 @@ A typical Git forking workflow can be used to contribute:
 
 For example, switch to this branch for issue 92: `blog/embertimes-92`
 
-`git checkout blog/embertimes-92`
+`git switch blog/embertimes-92`
 
 - Find the latest blog issue template at `source/YYYY-MM-DD-the-ember-times-issue-#.md`
 


### PR DESCRIPTION
Some simple docs adjustments to change recommendations of `git checkout` to instead use `git switch`.

It's small, but `switch` is easier to understand. Encouraging the use of these commands I believe leads to a smoother learning curve for new developers which means easier community engagement.