### PR TITLE
Adds an alternative to `git switch`, classic checkout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,7 +94,7 @@ Thank you for contributing to The Ember Times! Let us know if you can be a guest
     git fetch upstream
 
     # Switch to the current Ember Times branch
-    git switch -t upstream/blog/embertimes-165
+    git switch -t upstream/blog/embertimes-165 # or, git checkout blog/embertimes-165
     ```
 
 1. Open the Markdown file for the current blog issue: `source/2020-10-09-the-ember-times-issue-165.md`.

--- a/documentations/general.md
+++ b/documentations/general.md
@@ -56,7 +56,9 @@ A typical Git forking workflow can be used to contribute:
 
 For example, switch to this branch for issue 92: `blog/embertimes-92`
 
-`git switch -t upstream/blog/embertimes-165`
+```bash
+git switch -t upstream/blog/embertimes-165 # or, git checkout blog/embertimes-165
+```
 
 - Find the latest blog issue template at `source/YYYY-MM-DD-the-ember-times-issue-#.md`
 


### PR DESCRIPTION
Changes in https://github.com/ember-learn/ember-blog/pull/807 were controversial. This adds `git checkout` as an alternative in case anyone has confusion or trouble around the `git switch` command.