### PR TITLE
add padding to inline html to fix layout issue in new design

### DIFF
--- a/source/2019-12-29-countdown-to-the-new-year-ember-code-snippet.md
+++ b/source/2019-12-29-countdown-to-the-new-year-ember-code-snippet.md
@@ -51,7 +51,7 @@ Starting version 3.0, you can [decide what library to use for syntax highlightin
 {{/let}}
 ```
 
-<figure>
+<figure class="mb-4">
   <img alt="Code snippet highlighted with Prism JS" src="/images/blog/2019-12-29/code-snippet-prism.png">
   <figcaption>Code snippet highlighted with Prism.js</figcaption>
 </figure>
@@ -66,7 +66,7 @@ Maybe you want [Highlight.js](https://highlightjs.org/) instead:
 {{/let}}
 ```
 
-<figure>
+<figure class="mb-4">
   <img alt="Code snippet highlighted with Highlight JS" src="/images/blog/2019-12-29/code-snippet-highlight.png">
   <figcaption>Code snippet highlighted with Highlight.js</figcaption>
 </figure>


### PR DESCRIPTION
This is a bit of a strange PR but I will do my best to explain it.

As it stands, this MR will make no difference to the blog. It is intended to fix an issue in #7 that we noticed with the `<figure>` inline html in a single post. 

This should be merged into master and it means that next time that #7 is rebased it will have this change, which should fix the layout issue that we faced in the new design 👍 

Closes https://github.com/ember-learn/ember-blog/issues/835