### PR TITLE
[after empress-blog migration] fix button styles

### DIFF
--- a/content/2016-ember-community-survey.html.md
+++ b/content/2016-ember-community-survey.html.md
@@ -29,8 +29,8 @@ about who is in the Ember community and how they work with the framework.
 To that end, we're pleased to announce
 the official 2016 Ember Community Survey!
 
-<a href="/ember-community-survey-2016" class="survey-button orange button">
-  Survey Landing Page <img src="/images/survey/right-arrow.png" alt="Arrow to the right" />
+<a href="https://emberjs.com/ember-community-survey-2016" class="es-button">
+  Survey Landing Page
 </a>
 
 Completing the survey should take about fifteen minutes. We will be accepting

--- a/content/2017-ember-community-survey.html.md
+++ b/content/2017-ember-community-survey.html.md
@@ -29,8 +29,8 @@ With 2017 already under way, we would like your help to learn
 about who is in the Ember community and how they work with the framework.
 To that end, we're pleased to announce the official 2017 Ember Community Survey.
 
-<a href="/ember-community-survey-2017" class="survey-button orange button">
-  Survey Landing Page <img src="/images/survey/right-arrow.png" alt="Arrow to the right" />
+<a href="https://emberjs.com/ember-community-survey-2017" class="es-button">
+  Survey Landing Page
 </a>
 
 This is our third year learning about the community's makeup and interests,
@@ -52,4 +52,3 @@ If you have any immediate questions, feel free to email
 Tom ([@tzellman](https://twitter.com/tzellman)) and
 the survey team via
 [survey@201-created.com](mailto:survey@201-created.com).
-

--- a/content/ember-community-survey.md
+++ b/content/ember-community-survey.md
@@ -9,7 +9,7 @@ tags: []
 ---
 
 
-What an incredible time to be in the Ember Community! 
+What an incredible time to be in the Ember Community!
 
 - Ember.js completed seven backward-compatible minor version releases in the last year.
 - An amazing 200+ community members contributed to core Ember projects (that's not even counting the 4500+ ember addons!)
@@ -18,8 +18,8 @@ What an incredible time to be in the Ember Community!
 
 With 2019 already under way, we would like your help to learn about who is in the Ember community and how they work with the framework. To that end, we're pleased to announce the official 2019 Ember Community Survey.
 
-<a href="/ember-community-survey-2019" class="survey-button orange button">
-Survey Landing Page <img src="/images/survey/right-arrow.png" alt="" role="presentation" />
+<a href="https://emberjs.com/ember-community-survey-2019" class="es-button">
+  Survey Landing Page
 </a>
 
 This is the fifth year we're learning about the community's makeup and interests, and we look forward to sharing the results at [EmberConf 2019](http://emberconf.com/) on March 18th. Over 1300 participants took part in the survey in 2018 ([2018 survey results](https://www.emberjs.com/ember-community-survey-2018/)) and we are aiming for even more participation this year!

--- a/content/the-ember-times-issue-53.md
+++ b/content/the-ember-times-issue-53.md
@@ -109,7 +109,7 @@ Interested in the whole conversation? Checkout [@Alonski's](https://github.com/A
 </div>
 
 <div class="blog-row">
-  <a class="ember-button" href="https://discuss.emberjs.com/t/readers-questions-can-i-start-using-module-unification-in-my-app/15029">Read more</a>
+  <a class="es-button" href="https://discuss.emberjs.com/t/readers-questions-can-i-start-using-module-unification-in-my-app/15029">Read more</a>
 </div>
 
 <div class="blog-row">

--- a/content/the-ember-times-issue-54.md
+++ b/content/the-ember-times-issue-54.md
@@ -87,7 +87,7 @@ You can also check out the release blog post's **Deprecations** sections to ensu
 next major release. Read all about 👀 it on the Ember Blog:
 
 <div class="blog-row">
-  <a class="ember-button"
+  <a class="es-button"
     href="https://www.emberjs.com/blog/2018/07/02/ember-3-2-released.html"
     target="blog"
     aria-label="Read more about the 3.2 Ember release on the Ember blog">Read more</a>

--- a/content/the-ember-times-issue-60.md
+++ b/content/the-ember-times-issue-60.md
@@ -91,7 +91,7 @@ For the most up-to-date Ember reference material, check out the [Guides](https:/
   <p>This week's Readers' Question is all about best practices in Ember apps and one of the most popular design patterns - the <strong>"Data Down, Actions Up"
   paradigm</strong> - is explained in more detail. Read this week's answer by <a href="https://github.com/jessica-jordan" target="gh-jj">@jessica-jordan</a> on the <a href="https://discuss.emberjs.com/t/readers-questions-what-is-meant-by-the-term-data-down-actions-up/15311" target="discuss">official Ember Forum here</a>.</p>
 
-<p><a class="ember-button" href="https://discuss.emberjs.com/t/readers-questions-what-is-meant-by-the-term-data-down-actions-up/15311" target="compmanager">Read more</a></p>
+<p><a class="es-button" href="https://discuss.emberjs.com/t/readers-questions-what-is-meant-by-the-term-data-down-actions-up/15311" target="compmanager">Read more</a></p>
 <br/>
 
 <p><strong>Submit your own</strong> short and sweet <strong>question</strong> under <a href="https://bit.ly/ask-ember-core" target="rq">bit.ly/ask-ember-core</a>. And don’t worry, there are no silly questions, we appreciate them all - promise! 🤞</p>

--- a/content/the-ember-times-issue-62.md
+++ b/content/the-ember-times-issue-62.md
@@ -135,7 +135,7 @@ Simply run `ember-cli-update --run-codemods`, select which codemods to run and u
 
 <p>In this week's Readers' Question, Ember Learning Core team member <a href="https://github.com/jessica-jordan" target="jj">@jessica-jordan</a> will highlight the <strong>differences</strong> between some of the most <strong>popular JavaScript bundlers and build tools</strong> and explain why Ember CLI embraced <strong>Broccoli</strong> as its tool of choice early on. You can read her <a href="https://discuss.emberjs.com/t/readers-questions-why-does-ember-use-broccoli-and-how-is-it-different-from-webpack-rollup-parcel/15384" target="rq">full answer on the official Ember Forum.</a></p>
 
-<p><a class="ember-button" href="https://discuss.emberjs.com/t/readers-questions-why-does-ember-use-broccoli-and-how-is-it-different-from-webpack-rollup-parcel/15384" target="rq">Read more</a></p>
+<p><a class="es-button" href="https://discuss.emberjs.com/t/readers-questions-why-does-ember-use-broccoli-and-how-is-it-different-from-webpack-rollup-parcel/15384" target="rq">Read more</a></p>
 <br/>
 
 <p><strong>Submit your own</strong> short and sweet <strong>question</strong> under <a href="https://bit.ly/ask-ember-core" target="rq">bit.ly/ask-ember-core</a>. And don’t worry, there are no silly questions, we appreciate them all - promise! 🤞</p>

--- a/content/the-ember-times-issue-73.md
+++ b/content/the-ember-times-issue-73.md
@@ -34,7 +34,7 @@ Out of ideas? Be sure to [check out the Brainstorm CFP](https://emberconf.com/cf
 Not feeling ready yet? Be assured, that **you are ready** to tell us your story - we're convinced that you'll succeed! ✨
 
 <div class="blog-row">
-  <a class="ember-button" style="width:260px" href="https://emberconf.com/become-a-speaker.html">Ok, let me check out the CFP</a>
+  <a class="es-button" style="width:260px" href="https://emberconf.com/become-a-speaker.html">Ok, let me check out the CFP</a>
 </div>
 
 ---

--- a/content/the-ember-times-issue-78.md
+++ b/content/the-ember-times-issue-78.md
@@ -75,7 +75,7 @@ Read and comment on the [full RFC on GitHub](https://github.com/emberjs/rfcs/pul
 2019 is rapidly approaching, and you've got one more thing to do before EOY: buy your EmberConf ticket! This year's Early-Bird discount is significant ($50), while supplies last or until 12/31. So before anything else, here's that big shiny button! 🆗
 
 <div class="blog-row">
-  <a class="ember-button" style="width:260px" href="https://emberconf.com/register.html">Register Now</a>
+  <a class="es-button" style="width:260px" href="https://emberconf.com/register.html">Register Now</a>
 </div>
 
 The program has been announced and is looking really great: so many new faces, and a bunch of familiar old ones! Be sure to check out the [full schedule](https://emberconf.com/schedule.html) for all the details.

--- a/content/the-ember-times-issue-87.md
+++ b/content/the-ember-times-issue-87.md
@@ -93,7 +93,7 @@ A large part of the work for **Octane** ⛽️ is documentation! **Would you lik
   Ember Learning team member <a href="https://github.com/jessica-jordan" target="jj">@jessica-jordan</a> highlights in her answer some of the plethora of advantages that a data management library like Ember Data offers for <strong>building easy-to-maintain</strong> applications that also <strong>scale well</strong>.</p>
 
   <p>
-    <a class="ember-button" href="https://discuss.emberjs.com/t/readers-questions-what-are-the-benefits-of-using-ember-data-over-ajax/16254">Read more</a>
+    <a class="es-button" href="https://discuss.emberjs.com/t/readers-questions-what-are-the-benefits-of-using-ember-data-over-ajax/16254">Read more</a>
   </p>
 </div>
 

--- a/content/the-emberjs-times-issue-50.md
+++ b/content/the-emberjs-times-issue-50.md
@@ -99,7 +99,7 @@ We all love reading the Ember blog. It’s an awesome way to find out what’s h
 </div>
 
 <div class="blog-row">
-  <a class="ember-button" href="https://discuss.emberjs.com/t/readers-questions-id-like-to-contribute-to-ember-how-can-i-get-started/14915">Read more</a>
+  <a class="es-button" href="https://discuss.emberjs.com/t/readers-questions-id-like-to-contribute-to-ember-how-can-i-get-started/14915">Read more</a>
 </div>
 
 <div class="blog-row">


### PR DESCRIPTION
Important: this PR should not be merged until #7 is merged. When #7 is merged this PR should be changed to target master and merged as soon as possible 👍

This PR just updates some of the inline styles used to turn links into "buttons" to use the new es-button classes available in the ember-styleguide 👍

Fixes #831 