### PR TITLE
Add Analytics back after Ember migration

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,0 +1,22 @@
+import EmpressApplicationRoute from 'empress-blog/routes/application';
+import { inject as service } from '@ember/service';
+
+
+export default class ApplicationRoute extends EmpressApplicationRoute {
+  @service metrics;
+  @service router;
+
+  constructor() {
+    super(...arguments);
+
+    this.router.on('routeDidChange', () => {
+      const page = this.router.currentURL;
+      const title = this.router.currentRouteName ?? 'unknown';
+
+      // this is constant for this app and is only used to identify page views in the GA dashboard
+      const hostname = 'blog.emberjs.com';
+
+      this.metrics.trackPage({ page, title, hostname });
+    });
+  }
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -29,7 +29,18 @@ module.exports = function(environment) {
       paginate: true,
       logo: "/images/logos/e-icon.png",
       twitter: "emberjs",
-    }
+    },
+
+    metricsAdapters: [
+      {
+        name: 'GoogleAnalytics',
+        environments: ['production'],
+        config: {
+          id: 'UA-27675533-1',
+          require: ['linkid']
+        }
+      },
+    ],
   };
 
   if (environment === 'development') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "ember-fetch": "^8.0.2",
         "ember-load-initializers": "^2.1.1",
         "ember-maybe-import-regenerator": "^0.1.6",
+        "ember-metrics": "^1.0.0",
         "ember-qunit": "^4.6.0",
         "ember-resolver": "^8.0.2",
         "ember-source": "~3.21.1",
@@ -15000,6 +15001,89 @@
       "dev": true,
       "dependencies": {
         "object-assign": "4.1.1"
+      }
+    },
+    "node_modules/ember-metrics": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-metrics/-/ember-metrics-1.0.0.tgz",
+      "integrity": "sha512-YM8Q79BwvebT01+eqDEjgRPPcQQ8xWuarAKqdRsfvti0n9FerONhpygRFiX5HAGlBU24kaxWsRG67ybBK4tuRA==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-funnel": "^3.0.2",
+        "ember-cli-babel": "^7.22.1"
+      },
+      "engines": {
+        "node": "10.* || >= 12"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-funnel": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.3.tgz",
+      "integrity": "sha512-LPzZ91BwStoHZXdXHQAJeYORl189OrRKM5NdIi86SDU9wZ4s/3lV1PRFOiobDT/jKM10voM7CDzfvicHbCYxAQ==",
+      "dev": true,
+      "dependencies": {
+        "array-equal": "^1.0.0",
+        "blank-object": "^1.0.1",
+        "broccoli-plugin": "^4.0.1",
+        "debug": "^4.1.1",
+        "fast-ordered-set": "^1.0.0",
+        "fs-tree-diff": "^2.0.1",
+        "heimdalljs": "^0.2.0",
+        "minimatch": "^3.0.0",
+        "path-posix": "^1.0.0",
+        "walk-sync": "^2.0.2"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/broccoli-plugin": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.3.tgz",
+      "integrity": "sha512-CtAIEYq5K+4yQv8c/BHymOteuyjDAJfvy/asu4LudIWcMSS7dTn3yGI5gNBkwHG+qlRangYkHJNVAcDZMQbSVQ==",
+      "dev": true,
+      "dependencies": {
+        "broccoli-node-api": "^1.6.0",
+        "broccoli-output-wrapper": "^3.2.1",
+        "fs-merger": "^3.1.0",
+        "promise-map-series": "^0.2.1",
+        "quick-temp": "^0.1.3",
+        "rimraf": "^3.0.0",
+        "symlink-or-copy": "^1.3.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/fs-tree-diff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+      "dev": true,
+      "dependencies": {
+        "@types/symlink-or-copy": "^1.2.0",
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/ember-metrics/node_modules/walk-sync": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "ensure-posix-path": "^1.1.0",
+        "matcher-collection": "^2.0.0",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": "8.* || >= 10.*"
       }
     },
     "node_modules/ember-modifier-manager-polyfill": {
@@ -43159,6 +43243,76 @@
           "dev": true,
           "requires": {
             "object-assign": "4.1.1"
+          }
+        }
+      }
+    },
+    "ember-metrics": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ember-metrics/-/ember-metrics-1.0.0.tgz",
+      "integrity": "sha512-YM8Q79BwvebT01+eqDEjgRPPcQQ8xWuarAKqdRsfvti0n9FerONhpygRFiX5HAGlBU24kaxWsRG67ybBK4tuRA==",
+      "dev": true,
+      "requires": {
+        "broccoli-funnel": "^3.0.2",
+        "ember-cli-babel": "^7.22.1"
+      },
+      "dependencies": {
+        "broccoli-funnel": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-3.0.3.tgz",
+          "integrity": "sha512-LPzZ91BwStoHZXdXHQAJeYORl189OrRKM5NdIi86SDU9wZ4s/3lV1PRFOiobDT/jKM10voM7CDzfvicHbCYxAQ==",
+          "dev": true,
+          "requires": {
+            "array-equal": "^1.0.0",
+            "blank-object": "^1.0.1",
+            "broccoli-plugin": "^4.0.1",
+            "debug": "^4.1.1",
+            "fast-ordered-set": "^1.0.0",
+            "fs-tree-diff": "^2.0.1",
+            "heimdalljs": "^0.2.0",
+            "minimatch": "^3.0.0",
+            "path-posix": "^1.0.0",
+            "walk-sync": "^2.0.2"
+          }
+        },
+        "broccoli-plugin": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.3.tgz",
+          "integrity": "sha512-CtAIEYq5K+4yQv8c/BHymOteuyjDAJfvy/asu4LudIWcMSS7dTn3yGI5gNBkwHG+qlRangYkHJNVAcDZMQbSVQ==",
+          "dev": true,
+          "requires": {
+            "broccoli-node-api": "^1.6.0",
+            "broccoli-output-wrapper": "^3.2.1",
+            "fs-merger": "^3.1.0",
+            "promise-map-series": "^0.2.1",
+            "quick-temp": "^0.1.3",
+            "rimraf": "^3.0.0",
+            "symlink-or-copy": "^1.3.0"
+          }
+        },
+        "fs-tree-diff": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+          "dev": true,
+          "requires": {
+            "@types/symlink-or-copy": "^1.2.0",
+            "heimdalljs-logger": "^0.1.7",
+            "object-assign": "^4.1.0",
+            "path-posix": "^1.0.0",
+            "symlink-or-copy": "^1.1.8"
+          }
+        },
+        "walk-sync": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+          "dev": true,
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^2.0.0",
+            "minimatch": "^3.0.4"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ember-fetch": "^8.0.2",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-metrics": "^1.0.0",
     "ember-qunit": "^4.6.0",
     "ember-resolver": "^8.0.2",
     "ember-source": "~3.21.1",


### PR DESCRIPTION
Just a bit of an oversight on my part on the empress-blog migration branch. If the build passes we should merge this 👍 we can only really test it in production