### PR TITLE
Fixed lint errors from markdownlint (Part 1)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -7,7 +7,6 @@
   "no-trailing-punctuation": false,
   "no-trailing-spaces": false,
   "no-multiple-blanks": false,
-  "MD004": false,
   "MD005": false,
   "MD007": false,
   "MD010": false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -7,7 +7,6 @@
   "no-trailing-punctuation": false,
   "no-trailing-spaces": false,
   "no-multiple-blanks": false,
-  "MD001": false,
   "MD003": false,
   "MD004": false,
   "MD005": false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -7,7 +7,6 @@
   "no-trailing-punctuation": false,
   "no-trailing-spaces": false,
   "no-multiple-blanks": false,
-  "MD003": false,
   "MD004": false,
   "MD005": false,
   "MD007": false,

--- a/content/ember-1-0-prerelease.html.md
+++ b/content/ember-1-0-prerelease.html.md
@@ -1,14 +1,12 @@
 ---
-title: ''
-authors: []
-date: 2012-08-03T00:00:00.000Z
-tags: []
----
---- 
 title: Ember 1.0 Prerelease
-author: Peter Wagenet
-tags: Releases, Version 1.x, Prerelease, 2012, Router
-responsive: true
+authors:
+  - peter-wagenet
+date: 2012-08-03T00:00:00.000Z
+tags:
+  - releases
+  - '2012'
+  - version-1-x
 ---
 
 We're pleased to announce the Ember 1.0 Prerelease. It's been a couple

--- a/content/ember-1-10-0-released.md
+++ b/content/ember-1-10-0-released.md
@@ -44,7 +44,7 @@ stagnation" is made of.
 
 ## New Features in Ember.js 1.10
 
-#### HTMLBars 0.8.5
+### HTMLBars 0.8.5
 
 Ember.js 1.10 is dependent on HTMLBars 0.8.5. To ease this and later template
 library version changes, Ember's template compiler will be packaged as a
@@ -82,7 +82,7 @@ review the instructions [published by Robert Jackson this week](/blog/2015/02/05
 and join the conversation at [discuss.emberjs.com](http://discuss.emberjs.com/)
 or on IRC.
 
-#### Performance Improvements
+### Performance Improvements
 
 Ember.js 1.8 introduced a performance regression that we expected to re-coup in
 the 1.10 release. In December the team at [Discourse](http://www.discourse.org/) created the
@@ -99,7 +99,7 @@ the core team and community. Specific goals include reactive rendering for
 HTMLBars, more optimized metal views, limiting observation, and refinements to the Ember
 object model.
 
-#### Chained Else Blocks
+### Chained Else Blocks
 
 HTMLBars is built using the Handlebars parser, and will continue to gain
 features related to template syntax. Ember 1.10 features support for chained
@@ -119,7 +119,7 @@ helpers.
 You can read more about the implemetation [in the Handlebars repo](https://github.com/wycats/handlebars.js/pull/892).
 Thanks to [@kpdecker](http://twitter.com/kpdecker) for this improvement.
 
-#### Block Params
+### Block Params
 
 Ember 1.10 introduces block parameters. Block params provide consistent
 scope to templates, and allow components to pass internal values to a downstream
@@ -174,7 +174,7 @@ export default Ember.Component.extend({
 
 Many thanks to [@\_mmun](https://twitter.com/_mmun) for the implementation of this new feature.
 
-#### Injected Properties
+### Injected Properties
 
 Ember 1.x has exposed two APIs for managing dependency injection. The first is
 the application initializer API, using `register` and `inject` methods on an
@@ -229,7 +229,7 @@ detail.
 
 Thanks to [slindberg](https://github.com/slindberg) for his implementation of this feature.
 
-#### Notable Deprecations
+### Notable Deprecations
 
 As Ember.js moves forward, various APIs are deprecated to allow for their
 removal in a later major release (such as 2.0). The
@@ -284,7 +284,7 @@ Ember.js 1.11 beta continues a series of releases iterating the framework
 toward our 2.0 goals. In six weeks, these and a few other features will
 be declared stable.
 
-#### Inline if
+### Inline if
 
 In 1.11 Ember's `if` helper can be used in the inline form:
 
@@ -295,7 +295,7 @@ In 1.11 Ember's `if` helper can be used in the inline form:
 Thanks to [@marciojunior\_me](https://twitter.com/marciojunior_me) for
 implementing this feature.
 
-#### Each with Index
+### Each with Index
 
 The `each` helper will support an `index` block param in Ember 1.11:
 
@@ -309,7 +309,7 @@ The `each` helper will support an `index` block param in Ember 1.11:
 Thanks to [@\_mmun](https://twitter.com/_mmun) for
 implementing this feature.
 
-#### Bound Attribute Syntax
+### Bound Attribute Syntax
 
 Current Ember developers are familiar with the `bind-attr` syntax, used
 to declare an attribute binding on an HTML element. An original
@@ -372,7 +372,7 @@ Many thanks to [@mixonic](http://twitter.com/mixonic), [@\_mmun](http://twitter.
 and [@wycats](http://twitter.com/wycats) for their effort on the design and implementation
 of this feature.
 
-#### Named Substates
+### Named Substates
 
 Two routing substates exist for Ember routes. The `loading` substate will be entered
 if the async hooks of a route are still processing, and the `error` substate will be
@@ -388,7 +388,7 @@ onto the substate. So a valid loading substate for `application` can be defined 
 
 Thanks to [@machty](http://twitter.com/machty) for landing this feature.
 
-#### Component Helper
+### Component Helper
 
 Ember components can be bound via the `component` helper. For example this logic
 in a template:
@@ -417,7 +417,7 @@ the value of the property changes, the rendered component will also change.
 A big thank you to [@lukemelia](https://twitter.com/lukemelia) for shipping
 this new feature.
 
-#### Notable Deprecations in 1.11
+### Notable Deprecations in 1.11
 
 The following deprecations are scheduled for release with Ember.js 1.11:
 

--- a/content/ember-1-10-0-released.md
+++ b/content/ember-1-10-0-released.md
@@ -236,20 +236,20 @@ removal in a later major release (such as 2.0). The
 [deprecations page](/deprecations/) summarizes
 deprecations and demonstrates how to update to a new API.
 
-* The explicit `{{bind}}` helper has been deprecated. This helper has
+- The explicit `{{bind}}` helper has been deprecated. This helper has
   long been marked private, and was a legacy Sproutcore
   feature. This helper will be removed in Ember 1.11.
-* Quote-less outlet names are deprecated in 1.10. An example of this is
+- Quote-less outlet names are deprecated in 1.10. An example of this is
   `{{outlet modal}}`, which should be re-written as `{{outlet "modal"}}`.
   This ensures the outlet helper is consistent with others, where unquoted
   words are values and not string literals.
-* The `beforeObserver` feature is deprecated in Ember 1.10. Before observers
+- The `beforeObserver` feature is deprecated in Ember 1.10. Before observers
   are rarely used, but introduce significant overhead to the observer system
   in general. For observer use that requires the previous value of a property
   be known, implementing a cache is simple and more efficient. Read more about
   how to do this on [the deprecations page](/deprecations/v1.x#toc_deprecate-beforeobservers).
-* Observing the `childViews` array of a `ContainerView` is deprecated.
-* Setting the `childViews` property on a view definition is deprecated in
+- Observing the `childViews` array of a `ContainerView` is deprecated.
+- Setting the `childViews` property on a view definition is deprecated in
   1.10. For example:
 
 ```js
@@ -421,7 +421,7 @@ this new feature.
 
 The following deprecations are scheduled for release with Ember.js 1.11:
 
-* The `ObjectController` will be removed in Ember 2.0. In Ember 1.11,
+- The `ObjectController` will be removed in Ember 2.0. In Ember 1.11,
   both explicitly using an `ObjectController` and using the proxying behavior
   of a generated `ObjectController` will raise deprecation warnings.
 
@@ -430,8 +430,8 @@ may be added to the 1.11 release.
 
 ## Changelogs
 
-+ [Ember.js 1.10.0 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.10.0/CHANGELOG.md)
-+ [Ember.js 1.11.0-beta.1 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.11.0-beta.1/CHANGELOG.md)
+- [Ember.js 1.10.0 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.10.0/CHANGELOG.md)
+- [Ember.js 1.11.0-beta.1 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.11.0-beta.1/CHANGELOG.md)
 
 *Using Ember? Please take ten minutes to share your
 feedback by participating in the [2015 Ember Community Survey](http://goo.gl/forms/6yIsF3TNsQ). Open

--- a/content/ember-1-11-0-released.md
+++ b/content/ember-1-11-0-released.md
@@ -234,20 +234,20 @@ land in Ember.js 1.13.
 
 The following deprecations are scheduled for release with Ember.js 1.11:
 
-* The `ObjectController` will be removed in Ember 2.0. In Ember 1.11,
+- The `ObjectController` will be removed in Ember 2.0. In Ember 1.11,
   both explicitly using an `ObjectController` and using the proxying behavior
   of a generated `ObjectController` will raise deprecation warnings. See the
   [deprecation guide](/guides/deprecations#toc_objectcontroller) for more details.
-* Initializing instances (via `container.lookup`) in initializers is deprecated. For
+- Initializing instances (via `container.lookup`) in initializers is deprecated. For
   initialization that requires instances Ember has introduced "instance initializers". See
   the [deprecation guide](/guides/deprecations#toc_access-to-instances-in-initializers)
   for more information, as well as this [documentation PR](https://github.com/emberjs/website/pull/1951)
   and [the implementation PR](https://github.com/emberjs/ember.js/pull/10256).
-* Not a deprecation, but related: The `{{bind}}` template helper was a private
+- Not a deprecation, but related: The `{{bind}}` template helper was a private
   helper, and has been deprecated
   since Ember 1.10. It has been removed in Ember.js 1.11.
 
 ## Changelogs
 
-+ [Ember.js 1.11.0 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.11.0/CHANGELOG.md)
-+ [Ember.js 1.12.0-beta.1 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.12.0-beta.1/CHANGELOG.md)
+- [Ember.js 1.11.0 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.11.0/CHANGELOG.md)
+- [Ember.js 1.12.0-beta.1 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.12.0-beta.1/CHANGELOG.md)

--- a/content/ember-1-11-0-released.md
+++ b/content/ember-1-11-0-released.md
@@ -19,7 +19,7 @@ across over 646 commits.
 
 ## New Features in Ember.js 1.11
 
-#### Bound Attribute Syntax
+### Bound Attribute Syntax
 
 Current Ember developers are familiar with the `bind-attr` syntax, used
 to declare an attribute binding on an HTML element. An original
@@ -83,7 +83,7 @@ Many thanks to [@mixonic](http://twitter.com/mixonic), [@\_mmun](http://twitter.
 and [@wycats](http://twitter.com/wycats) for their effort on the design and implementation
 of this feature.
 
-#### Escaping Content in HTMLBars
+### Escaping Content in HTMLBars
 
 Bound attribute syntax introduces several new uses of mustaches
 (the `{{` syntax used in Ember templates). These new uses
@@ -150,7 +150,7 @@ export default Ember.Component.extend({
 A less savory alternative is to use the `{{{` "escaped mustache" style. There are
 plans to improve escaped content as we approach 2.0.
 
-#### Inline if
+### Inline if
 
 In 1.11 Ember's `if` helper can be used in the inline form:
 
@@ -161,7 +161,7 @@ In 1.11 Ember's `if` helper can be used in the inline form:
 Thanks to [@eaf4](https://twitter.com/eaf4) and [@marciojunior\_me](https://twitter.com/marciojunior_me) for
 implementing this feature.
 
-#### Each with Index
+### Each with Index
 
 The `each` helper will support an `index` block param in Ember 1.11:
 
@@ -175,7 +175,7 @@ The `each` helper will support an `index` block param in Ember 1.11:
 Thanks to [@timmyce](https://twitter.com/timmyce) and [@\_mmun](https://twitter.com/_mmun) for
 implementing this feature.
 
-#### Named Substates
+### Named Substates
 
 Two routing substates exist for Ember routes. The `loading` substate will be entered
 if the async hooks of a route are still processing, and the `error` substate will be
@@ -191,7 +191,7 @@ onto the substate. So a valid loading substate for `application` can be defined 
 
 Thanks to [@machty](http://twitter.com/machty) for landing this feature.
 
-#### Component Helper
+### Component Helper
 
 Ember components can be bound via the `component` helper. For example this logic
 in a template:
@@ -218,7 +218,7 @@ the value of the property changes, the rendered component will also change.
 A big thank you to [@lukemelia](https://twitter.com/lukemelia) for shipping
 this new feature.
 
-#### Performance Improvements
+### Performance Improvements
 
 Ember.js 1.10 has favorable rendering performance compared to previous releases. We're
 pleased that Ember 1.11 builds upon that progress. Compared to 1.10, common list
@@ -230,7 +230,7 @@ Progress continues on the [Glimmer rendering engine](https://github.com/emberjs/
 announced at EmberConf 2015. This dramatic performance improvement is expected to
 land in Ember.js 1.13.
 
-#### Notable Deprecations in 1.11
+### Notable Deprecations in 1.11
 
 The following deprecations are scheduled for release with Ember.js 1.11:
 

--- a/content/ember-1-11-1-released.md
+++ b/content/ember-1-11-1-released.md
@@ -34,10 +34,10 @@ This regression is fixed in 1.11.1.
 
 A couple regressions were fixed for Handlebars helpers with 1.11.1:
 
-* The inverse template (aka `{{else}}` block) of Handlebars helpers was not properly accounted
+- The inverse template (aka `{{else}}` block) of Handlebars helpers was not properly accounted
   for during the HTMLBars transition. Using an `{{else}}` block with a Handlebars helper has
   not been function since 1.9.0.
-* The main block could not be rendered even if `options.fn()` was called within the helper. This
+- The main block could not be rendered even if `options.fn()` was called within the helper. This
 regression was first introduced in 1.11.0-beta.4.
 
 ### Incorrect Assertion for {{each foos itemControler='bar'}}
@@ -57,5 +57,5 @@ but if you do not the views template will be defaulted to a template with the sa
 
 ## Changelogs
 
-+ [Ember.js 1.11.0 to 1.11.1 commit log](https://github.com/emberjs/ember.js/compare/v1.11.0...v1.11.1)
-+ [Ember.js 1.11.1 CHANGELOG](https://github.com/emberjs/ember.js/releases/tag/v1.11.1)
+- [Ember.js 1.11.0 to 1.11.1 commit log](https://github.com/emberjs/ember.js/compare/v1.11.0...v1.11.1)
+- [Ember.js 1.11.1 CHANGELOG](https://github.com/emberjs/ember.js/releases/tag/v1.11.1)

--- a/content/ember-1-12-released.md
+++ b/content/ember-1-12-released.md
@@ -23,7 +23,7 @@ Ember 1.12 is a relatively light release, and includes features that move Ember
 closer to ES6 class syntax and the first parts of the internal implementation
 needed for a stable release of the FastBoot addon.
 
-#### New Computed Syntax
+### New Computed Syntax
 
 Per [RFC #11](https://github.com/emberjs/rfcs/pull/11), Ember is introducing a
 new syntax for computed properties. This change better aligns computed property
@@ -124,7 +124,7 @@ export default Ember.Object.extend({
 
 [decorators]: https://github.com/wycats/javascript-decorators
 
-#### Instance Initializers
+### Instance Initializers
 
 The next feature, instance initializers, makes it possible for FastBoot
 applications to run many requests concurrently.
@@ -186,7 +186,7 @@ Thanks to [@tomdale](https://twitter.com/tomdale), [@wycats](https://twitter.com
 [@dgeb](https://twitter.com/dgeb) for this feature and other
 refactoring work around application initialization.
 
-#### Initializer Context
+### Initializer Context
 
 Previously, the `this` scope of an initializer was simply the global scope.
 [#10179](https://github.com/emberjs/ember.js/pull/10179) changed initializer
@@ -225,7 +225,7 @@ finish line. It's inspiring.
 
 [almost]: https://www.isemberfastyet.com
 
-#### The 1.13.x Series
+### The 1.13.x Series
 
 In most cases, you should expect Glimmer to be faster at both initial rendering
 and updates. If you find performance regressions in idiomatic usage in your app,

--- a/content/ember-1-13-0-released.md
+++ b/content/ember-1-13-0-released.md
@@ -46,7 +46,7 @@ to fire should upgrade to 2.0 without changes.
 
 The easiest way to work through deprecations is the **Ember Inspector**. Thanks to the work of Teddy Zeenny, deprecations will be routed to the "Deprecations" inspector pane, where you can get a grouped list of them as well as the line of code in your app that triggered the deprecation. You can also ask for a full stack trace of any deprecation.
 
-#### Improved Rerender Performance
+### Improved Rerender Performance
 
 Previous iterations of Ember's rendering engine **relied** on granular observation for efficiency. When a piece of dynamic content was rendered, Ember registered observers, updating the content when the value changed.
 
@@ -81,7 +81,7 @@ Glimmer's performance, and to [LinkedIn](http://www.linkedin.com) and
 [Bustle](http://www.bustle.com/) for their
 generous sponsorship of this work.
 
-#### Component Lifecycle Hooks
+### Component Lifecycle Hooks
 
 A number of new component lifecycle hooks have been introduced to Ember 1.13.
 Using these hooks allows you to write data down, action up (DDAU) style
@@ -128,7 +128,7 @@ Note that a component is re-rendered whenever:
 Because of the Glimmer engine, these re-renders are fast, and avoid
 unnecessary work.
 
-#### Closure Actions
+### Closure Actions
 
 In Ember 1.x, the actions system used bubbling as a solution for passing user
 behavior to a parent scope. For example, when clicking a button an action
@@ -187,11 +187,11 @@ Additionally the `action` helper has two options:
   off whatever the first argument to the called action is. This is handy for
   destructuring objects passed as the first argument (like DOM events).
 
-#### Note: Angle Bracket Components
+### Note: Angle Bracket Components
 
 Ember 2.1 will (likely) ship with angle-bracket components, which will introduce one-way data flow **by default**, and provide an opt-in for two-way data flow. Existing components maintain the existing behavior (for compatibility). While the internals of Ember 2.0 support a distinction between one-way and two-way bindings, that distinction will remain largely internal until Ember 2.1.
 
-#### New Ember.js Helper API
+### New Ember.js Helper API
 
 Ember's helper story prior to 1.13 has been inconsistent and neglected. In
 1.13, we're introducing a new API for writing helpers along with a set of
@@ -259,7 +259,7 @@ requirements for this API to our attention and testing changes with little notic
 Thanks to [@mixonic](https://twitter.com/mixonic)
 and [@rwjblue](https://twitter.com/rwjblue) for the implementation.
 
-#### Component Block Info
+### Component Block Info
 
 Ember.js 1.13 introduces two new template keywords that provide reflection on
 how a component is called.
@@ -293,7 +293,7 @@ with block params (invoke in block form with `as |someParam|`).
 Thanks to [@mmun](https://twitter.com/_mmun) and [@rwjblue](https://twitter.com/rwjblue)
 for implementing this feature.
 
-#### Notable Deprecations in 1.13
+### Notable Deprecations in 1.13
 
 In preparation for Ember 2.0, 1.13 introduces many deprecations. These include:
 
@@ -335,7 +335,7 @@ iterate forward.
 Because of the focus on landing migration paths for 1.x codebases in 1.13,
 2.0 will have few new features. Among them are:
 
-#### each-in helper
+### each-in helper
 
 The `each-in` helper allows the iteration of object properties. For example,
 given this value for `items`:
@@ -361,7 +361,7 @@ cause a rerender, but `.set('items', val)` will.
 Thanks to [@tomdale](http://twitter.com/tomdale) and implementing this
 feature, and to several others for helping push it to completion.
 
-#### get helper
+### get helper
 
 The `get` helper provides a bound way to fetch a single property from an object.
 For example given these items:
@@ -387,7 +387,7 @@ This becomes more powerful when the second argument is a bound path:
 
 Thanks to [@jmurphyau](https://twitter.com/jmurphyau) for implementing this feature.
 
-#### Notable Breaking Changes in Ember 2.0
+### Notable Breaking Changes in Ember 2.0
 
 Ember 2.0 will remove a number of public APIs, all of which should have been
 deprecated in the 1.13 release and have a viable migration path. The Ember

--- a/content/ember-1-13-0-released.md
+++ b/content/ember-1-13-0-released.md
@@ -52,12 +52,12 @@ Previous iterations of Ember's rendering engine **relied** on granular observati
 
 While this was reasonably efficient in cases where the developer could easily use `set` (and the array equivalents) to mutate values, it had two related issues:
 
-* This forced developers to represent all changes in terms of granular
+- This forced developers to represent all changes in terms of granular
   observers. In many cases this could be extremely awkward. This was
   especially problematic when working with Arrays, since (for example)
   representing a sort as a series of mutations is conceptually complex
   and can be cost-prohibitive.
-* Ember itself was extremely inefficient when an entire object or
+- Ember itself was extremely inefficient when an entire object or
   array was replaced, despite the fact that this was often the most
   natural way to represent the change. This meant that while it was
   usually possible in theory to "just re-render" a component, it was,
@@ -89,33 +89,33 @@ components today, despite the two-way data binding of curly components.
 
 On first render (in order):
 
-* `didInitAttrs` runs after a component was created and passed attrs are guaranteed to be present. In Ember 1.13, the attributes will be available as `this.get('attrName')`.
-* `didReceiveAttrs` runs after `didInitAttrs`, and it also runs on
+- `didInitAttrs` runs after a component was created and passed attrs are guaranteed to be present. In Ember 1.13, the attributes will be available as `this.get('attrName')`.
+- `didReceiveAttrs` runs after `didInitAttrs`, and it also runs on
   subsequent re-renders, which is useful for logic that is the same
   on all renders. It does not run when the component has been re-rendered from the inside.
-* `willRender` runs before the template is rendered. It runs when the
+- `willRender` runs before the template is rendered. It runs when the
   template is updated for any reason (both initial and re-render, and
   regardless of whether the change was caused by an attrs change or
   re-render).
-* `didInsertElement` runs after the template has rendered and the
+- `didInsertElement` runs after the template has rendered and the
   element is in the DOM.
-* `didRender` runs after `didInsertElement` (it also runs on subsequent
+- `didRender` runs after `didInsertElement` (it also runs on subsequent
   re-renders).
 
 On re-render (in order):
 
-* `didUpdateAttrs` runs when the attributes of a component have changed
+- `didUpdateAttrs` runs when the attributes of a component have changed
   (but not when the component is re-rendered, via `component.rerender`,
   `component.set`, or changes in models or services used by the
   template).
-* `didReceiveAttrs`, same as above.
-* `willUpdate` runs when the component is re-rendering for any reason,
+- `didReceiveAttrs`, same as above.
+- `willUpdate` runs when the component is re-rendering for any reason,
   including `component.rerender()`, `component.set()` or changes in
   models or services used by the template.
-* `willRender`, same as above
-* `didUpdate` runs after the template has re-rendered and the DOM is
+- `willRender`, same as above
+- `didUpdate` runs after the template has re-rendered and the DOM is
   now up to date.
-* `didRender`, same as above.
+- `didRender`, same as above.
 
 Note that a component is re-rendered whenever:
 
@@ -173,17 +173,17 @@ export default Ember.Component.extend({
 
 Actions:
 
-* Can be passed multiple arguments
-* Return a value. For example `var result = this.attrs.submit();`
-* Can curry. For example `submit=(action 'setName' 'Sal')` would pass `"Sal"` as
+- Can be passed multiple arguments
+- Return a value. For example `var result = this.attrs.submit();`
+- Can curry. For example `submit=(action 'setName' 'Sal')` would pass `"Sal"` as
   the first argument to `setName` when `submit` is called. Actions can curry
   multiple times, adding arguments at each scope. For example `submit=(action attrs.actionPassedIn someProp)` just adds an argument to any already curried onto `actionPassedIn`.
 
 Additionally the `action` helper has two options:
 
-* `(action 'save' target=session)` would look at the `actions` hash on the
+- `(action 'save' target=session)` would look at the `actions` hash on the
   `session` object instead of the current context.
-* `(action 'save' value="currentTarget.value")` would read the path `currentTarget.value`
+- `(action 'save' value="currentTarget.value")` would read the path `currentTarget.value`
   off whatever the first argument to the called action is. This is handy for
   destructuring objects passed as the first argument (like DOM events).
 
@@ -199,11 +199,11 @@ constraints and features informed by real-world experience.
 
 Ember helpers:
 
-* Represent a single value
-* Do not manage DOM or control flow
-* Can recompute themselves, similar to how a component can rerender
-* Can optionally access services
-* Do not require a dash
+- Represent a single value
+- Do not manage DOM or control flow
+- Can recompute themselves, similar to how a component can rerender
+- Can optionally access services
+- Do not require a dash
 
 Helpers come in two flavors. The first is a function-based API we call a
 shorthand helper. For example, this shorthand helper joins a first and
@@ -297,22 +297,22 @@ for implementing this feature.
 
 In preparation for Ember 2.0, 1.13 introduces many deprecations. These include:
 
-* All view APIs in Ember. [See deprecation guide](http://emberjs.com/deprecations/v1.x/#toc_ember-view)
-  * `Ember.CoreView`, `Ember.View`, `Ember.CollectionView`, `Ember.ContainerView`
-  * `{{view 'some-helper'}}`
-  * The `{{view}}` keyword for accessing properties on a view
-  * `Ember.Select` and `{{view "select"}}`. [See deprecation guide](http://emberjs.com/deprecations/v1.x/#toc_ember-select)
-  * `Ember.LinkView` in favor of `Ember.LinkComponent`. [See deprecation guide](http://emberjs.com/deprecations/v1.x/#toc_ember-linkview)
-* Options to the `{{#each` helper that trigger a legacy and poorly performing
+- All view APIs in Ember. [See deprecation guide](http://emberjs.com/deprecations/v1.x/#toc_ember-view)
+  - `Ember.CoreView`, `Ember.View`, `Ember.CollectionView`, `Ember.ContainerView`
+  - `{{view 'some-helper'}}`
+  - The `{{view}}` keyword for accessing properties on a view
+  - `Ember.Select` and `{{view "select"}}`. [See deprecation guide](http://emberjs.com/deprecations/v1.x/#toc_ember-select)
+  - `Ember.LinkView` in favor of `Ember.LinkComponent`. [See deprecation guide](http://emberjs.com/deprecations/v1.x/#toc_ember-linkview)
+- Options to the `{{#each` helper that trigger a legacy and poorly performing
   legacy layer. These options are: `itemView`, `itemViewClass`, `tagName`, `emptyView` and `emptyViewClass`.
-* The `itemController` argument for `{{#each`.
-* The `bind-attr` helper. Using helpers and HTMLBars-style attribute binding
+- The `itemController` argument for `{{#each`.
+- The `bind-attr` helper. Using helpers and HTMLBars-style attribute binding
   is preferred.
-* Reading `this.get('template')` to check for a yielded block on components.
+- Reading `this.get('template')` to check for a yielded block on components.
   Instead, use the `hasBlock` API.
-* Non-block param `{{with`
-* The `view` and `viewClass` params for `{{outlet}}`
-* `Ember.reduceComputed` and `Ember.arrayComputed` in favor of plain normal
+- Non-block param `{{with`
+- The `view` and `viewClass` params for `{{outlet}}`
+- `Ember.reduceComputed` and `Ember.arrayComputed` in favor of plain normal
   array manipulations. [See deprecation guide](http://emberjs.com/deprecations/v1.x/#toc_ember-reducecomputed-ember-arraycomputed)
 
 ## Ember 2.0 beta
@@ -401,58 +401,58 @@ represents what we believe the breaking changes will be.
 Many controller APIs are removed in Ember 2.0. Routeable controllers still
 exist, but all other uses have been deprecated. This includes:
 
-* `{{render "some-controller"}}`
-* `{{each item itemController="some-controller"}}` - This usage can be replaced
+- `{{render "some-controller"}}`
+- `{{each item itemController="some-controller"}}` - This usage can be replaced
   by nesting a component inside the item, and by using helpers.
-* `Ember.ObjectController`
-* `Ember.ArrayController`
-* The `{{controller}}` keyword
-* `needs:` on controllers
+- `Ember.ObjectController`
+- `Ember.ArrayController`
+- The `{{controller}}` keyword
+- `needs:` on controllers
 
 All view APIs are removed in Ember 2.0. This includes:
 
-* `Ember.CoreView`, `Ember.View`, `Ember.ContainerView` and `Ember.CollectionView`
-* `Ember._Metamorph`, `Ember._MetamorphView`
-* The `{{view "some-view"}}` helper
-* The `{{view}}` keyword
-* `{{each itemView=`, `{{each itemViewClass=`, `{{each tagName=`, `{{each emptyView=`, `{{each emptyViewClass`
-* `Ember.Select` and `{{view "select"}}`
-* `Ember.Checkbox` is not removed, but will become a component instead of a view
+- `Ember.CoreView`, `Ember.View`, `Ember.ContainerView` and `Ember.CollectionView`
+- `Ember._Metamorph`, `Ember._MetamorphView`
+- The `{{view "some-view"}}` helper
+- The `{{view}}` keyword
+- `{{each itemView=`, `{{each itemViewClass=`, `{{each tagName=`, `{{each emptyView=`, `{{each emptyViewClass`
+- `Ember.Select` and `{{view "select"}}`
+- `Ember.Checkbox` is not removed, but will become a component instead of a view
 
 The most commonly used parts of the `view` API will be supported into the forseeable future via a core-supported addon.
 
 All Handlebars APIs are removed in Ember 2.0. This includes:
 
-* `Ember.Handlebars.helper`, `Ember.Handlebars.makeBoundHelper` and `Ember.Handlebars.helper`
-* `Ember.Handlebars.compile`
+- `Ember.Handlebars.helper`, `Ember.Handlebars.makeBoundHelper` and `Ember.Handlebars.helper`
+- `Ember.Handlebars.compile`
 
 Several template helpers are removed in Ember 2.0. These include:
 
-* `{{bindAttr}}`
-* `{{bind-attr}}` (use HTMLBars-style attribute bindings instead)
-* `{{bind}}`
-* `{{template}}` (use `{{partial}}` instead)
-* `{{linkTo}}` (use `{{link-to}}` instead)
-* `{{collection items}}`
-* Non-block params versions of `{{#each}}` and `{{#with}}`
-* Legacy arguments to `{{#each}}`, `{{outlet}}`
+- `{{bindAttr}}`
+- `{{bind-attr}}` (use HTMLBars-style attribute bindings instead)
+- `{{bind}}`
+- `{{template}}` (use `{{partial}}` instead)
+- `{{linkTo}}` (use `{{link-to}}` instead)
+- `{{collection items}}`
+- Non-block params versions of `{{#each}}` and `{{#with}}`
+- Legacy arguments to `{{#each}}`, `{{outlet}}`
 
 The following routing APIs are removed:
 
-* `#hash` paths with no forward leading slash
+- `#hash` paths with no forward leading slash
 
 Other APIs:
 
-* `Ember.tryFinally`
-* `Ember.tryCatchFinally`
-* `Ember.required`
-* `Ember.Map#remove`
-* `Ember.Set`
-* `Ember.computed.defaultTo`
-* `Ember.DeferredMixin`
-* `Ember.Deferred` (use `Ember.RSVP.Promise` instead)
-* `Ember.reduceComputed` and `Ember.arrayComputed` (use plain array manipulation)
-* `Ember.Freezable` (use Object.freeze instead)
+- `Ember.tryFinally`
+- `Ember.tryCatchFinally`
+- `Ember.required`
+- `Ember.Map#remove`
+- `Ember.Set`
+- `Ember.computed.defaultTo`
+- `Ember.DeferredMixin`
+- `Ember.Deferred` (use `Ember.RSVP.Promise` instead)
+- `Ember.reduceComputed` and `Ember.arrayComputed` (use plain array manipulation)
+- `Ember.Freezable` (use Object.freeze instead)
 
 Additionally, IE8 is no longer supported in Ember 2.x. IE9+ is supported.
 
@@ -460,5 +460,5 @@ Many of these deprecated APIs will be moved into core-supported addons, or have 
 
 ## Changelogs
 
-+ [Ember.js 1.13.0 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.13.0/CHANGELOG.md)
-+ [Ember.js 2.0.0-beta.1 CHANGELOG](https://github.com/emberjs/ember.js/blob/v2.0.0-beta.1/CHANGELOG.md)
+- [Ember.js 1.13.0 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.13.0/CHANGELOG.md)
+- [Ember.js 2.0.0-beta.1 CHANGELOG](https://github.com/emberjs/ember.js/blob/v2.0.0-beta.1/CHANGELOG.md)

--- a/content/ember-1-8-0-released.md
+++ b/content/ember-1-8-0-released.md
@@ -33,13 +33,13 @@ abandoning existing codebases.
 
 Some of the immediate benefits of this refactor are:
 
-* The removal of recursion from the rendering layer. This decreases garbage
+- The removal of recursion from the rendering layer. This decreases garbage
 collection pressure during rendering and allows the re-use of objects during
 render (for example, the render buffer).
-* Improved HTML namespace and contextual element tracking. This introduces
+- Improved HTML namespace and contextual element tracking. This introduces
 support for components, data-binding, and logic within inline SVG documents.
 [Example JSBin](http://jsbin.com/woxes/8/)
-* Prior versions of Ember.js relied upon script tags to mark
+- Prior versions of Ember.js relied upon script tags to mark
 regions of data bound content. For example a simple template of `{{name}}`
 might be rendered into the page as:
 
@@ -67,13 +67,13 @@ test their applications on 1.8 beta. Delivering this update without breaking
 Ember.js 1.8 comes with several performance improvements in other parts of the
 codebase.
 
-* Ember.js APIs often require the use of a string to lookup a class or route.
+- Ember.js APIs often require the use of a string to lookup a class or route.
 Often these strings must be passed through a normalization step before they are
 used, such as pluralizing, singularizing, or changing snake\_case to camelCase.
 1.8 introduces several caches for these operations, resulting in common
 operations being performed far fewer times.
-* The refactoring of commonly de-optimized functions in v8 and other browsers.
-* The conversion of `MANDATORY_SETTER` from a runtime flag into a build-time
+- The refactoring of commonly de-optimized functions in v8 and other browsers.
+- The conversion of `MANDATORY_SETTER` from a runtime flag into a build-time
 feature flag. This allows relevant code paths in `get` and `set` to be slimmer
 in production builds.
 
@@ -91,24 +91,24 @@ from old APIs.
 
 Four notable deprecations are added with the release of 1.8.
 
-* `Ember.Set` is a class for managing an unordered collection of objects ([api
+- `Ember.Set` is a class for managing an unordered collection of objects ([api
 docs](http://emberjs.com/api/classes/Ember.Set.html)). It is a private API and
 thus subject to change, however several libraries have chosen to use it despite
 this. Since the addition of this API to Ember, the ES6 draft has matured in its
 description of a native JavaScript Set class. `Ember.Set` is not compatible
 with the upcoming API, and is now deprecated.
-* In an effort to more closely align `Ember.Map` with ES6, the `remove` method
+- In an effort to more closely align `Ember.Map` with ES6, the `remove` method
 has been deprecated in favor of `delete`.
-* The `currentWhen` property on links is deprecated in favor of `current-when`.
+- The `currentWhen` property on links is deprecated in favor of `current-when`.
 This property name more closely tracks how component properties will be used in the
 future.
-* Old versions of Ember.js, the guides, and the API documentation suggested
+- Old versions of Ember.js, the guides, and the API documentation suggested
 looking up views as globals. For example `{{view App.SomeView}}`. In
 Ember.js 1.8 this style of view lookup is deprecated in favor of using a
 string, similar to how other class lookups behave in Ember. [See
 this page](http://emberjs.com/deprecations/v1.x#toc_global-lookup-of-views)
 for details about transitioning away from global view lookups.
-* URLs containing a hash and no `/`, such as `/foo#bar` are handled by the
+- URLs containing a hash and no `/`, such as `/foo#bar` are handled by the
 router's `hash` location handler. When using the `auto` location handler, the
 presence of `#` will cause the `hash` handler to be chosen over the `history`
 handlers, despite the lack of a leading `/` in the path (for example `/foo#/bar`.
@@ -126,22 +126,22 @@ deprecations).
 In this release there are several small breaking changes that may impact your
 application.
 
-* `didInsertElement` is now always called on a child view before it is called
+- `didInsertElement` is now always called on a child view before it is called
 on a rendering parent view. In previous releases of Ember.js `didInsertElement`
 would often be called first on a parent view, however this behavior was
 inconsistent. In general, developers are encouraged
 to consider scheduling work into the `afterRender` queue if it includes
 accessing DOM not immediately under that view's control.
-* Actions defined directly on the controller object
+- Actions defined directly on the controller object
 and not in the `actions:` hash have been deprecated since Ember.js 1.0. In
 Ember.js 1.8 support for those actions has been removed.
-* `Ember.Map` has been tweaked to more closely match the ES6 spec for `Map`. The
+- `Ember.Map` has been tweaked to more closely match the ES6 spec for `Map`. The
 `forEach` callback now takes `value,key,map` as arguments. Previously it was passed
 `key,value`. This API is private, but several libraries have chosen to use it
 despite this. Ember-Data now includes [a polyfill](https://github.com/emberjs/data/blob/master/packages/ember-data/lib/system/map.js). `Ember.OrderedSet`, a super class of `Ember.Map`, has
 also had minor ES6 cleanups applied.
 to allow consistent usage across the pre-1.8 and 1.8 API.
-* Ember.js has long had an run-time flag called `MANDATORY_SETTER`. With this
+- Ember.js has long had an run-time flag called `MANDATORY_SETTER`. With this
 flag enabled, attempts to set an observed object property without the use of
 `Ember.set()` would throw an error (a desirable behavior for development
 builds). This runtime flag has been changed to a
@@ -157,16 +157,16 @@ week for six weeks, then promoted to release.
 
 In Ember.js 1.9 several new features and changes will be introduced.
 
-* "Streams" are a new Ember.js internal that replace bindings at the lowest
+- "Streams" are a new Ember.js internal that replace bindings at the lowest
 level of the Ember rendering pipeline. They greatly simplify the implementation
 of template helpers and are yet another important step toward the landing of
 HTMLBars.
-* Handlebars 2.0 will be required for Ember.js 1.9. See [this summary
+- Handlebars 2.0 will be required for Ember.js 1.9. See [this summary
 of the transition](http://emberjs.com/blog/2014/10/16/handlebars-update.html)
 for more details.
-* Further performance improvements and bugfixes.
+- Further performance improvements and bugfixes.
 
 ## Changelogs
 
-+ [Ember.js 1.8.0 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.8.0/CHANGELOG.md)
-+ [Ember.js 1.9.0-beta.1 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.9.0-beta.1/CHANGELOG.md)
+- [Ember.js 1.8.0 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.8.0/CHANGELOG.md)
+- [Ember.js 1.9.0-beta.1 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.9.0-beta.1/CHANGELOG.md)

--- a/content/ember-1-8-1-released.md
+++ b/content/ember-1-8-1-released.md
@@ -46,8 +46,8 @@ in a number of modules, and we have expanded our work around for more modules in
 
 Further Reading:
 
-* https://bugs.webkit.org/show_bug.cgi?id=138038
-* https://github.com/emberjs/ember.js/issues/5606
+- https://bugs.webkit.org/show_bug.cgi?id=138038
+- https://github.com/emberjs/ember.js/issues/5606
 
 ### Support rendering of null-prototype objects
 
@@ -98,5 +98,5 @@ progress [here](https://code.google.com/p/chromium/issues/detail?id=428313).
 
 ## Changelogs
 
-+ [Ember.js 1.8.0 to 1.8.1 commit log](https://github.com/emberjs/ember.js/compare/v1.8.0...stable)
-+ [Ember.js 1.8.1 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.8.1/CHANGELOG.md)
+- [Ember.js 1.8.0 to 1.8.1 commit log](https://github.com/emberjs/ember.js/compare/v1.8.0...stable)
+- [Ember.js 1.8.1 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.8.1/CHANGELOG.md)

--- a/content/ember-1-9-0-released.md
+++ b/content/ember-1-9-0-released.md
@@ -34,7 +34,7 @@ complete API compatibility it demonstrates our commitment to stability without s
 
 ## New Features and Deprecations in Ember.js 1.9
 
-#### Handlebars 2.0
+### Handlebars 2.0
 
 As [announced in October](http://emberjs.com/blog/2014/10/16/handlebars-update.html), Ember.js 1.9
 adds support for Handlebars 2.0 templates and removes support for Handlebars 1.x templates. This
@@ -57,7 +57,7 @@ npm install --save-dev ember-cli-htmlbars@0.6.0
 
 Non-CLI applications will likewise require a bump of their Handlebars dependency version.
 
-#### Streams
+### Streams
 
 Data-binding in Ember.js has traditionally been based on the concept of a key-value
 observer. In Ember 1.x, KVO observers fire immediately upon the change of a value,
@@ -72,7 +72,7 @@ Ember's codebase for HTMLBars.
 Thanks to [@\_mmun](https://twitter.com/_mmun), [@ebryn](https://twitter.com/ebryn), and [@krisselden](https://twitter.com/krisselden) who wrote an Ember.js stream
 implementation then updated every Handlebars helper to the new API.
 
-#### Activate and Deactivate Events
+### Activate and Deactivate Events
 
 Ember.js routes have long supported an `activate` and `deactivate` hook.
 For example:
@@ -97,7 +97,7 @@ export default Ember.Route.extend({
 
 Thanks to [@pangratz](https://twitter.com/pangratz) for the addition of this feature.
 
-#### pauseTest
+### pauseTest
 
 When debugging an Ember acceptance test, it can be helpful to
 pause and inspect the DOM or application state.
@@ -115,7 +115,7 @@ test('clicking login authenticates', function(){
 
 Thanks to [@katiegengler](https://twitter.com/katiegengler) for the addition of this feature.
 
-#### key-up and key-down actions
+### key-up and key-down actions
 
 The `{{input}}` and `{{textarea}}` helpers in Ember emit several
 actions, including `enter`, `insert-newline`, `escape-press`, `focus-in`,
@@ -129,7 +129,7 @@ This release introduces `key-up` and `key-down` actions. For example:
 {{input value=name key-up="validateName"}}
 ```
 
-#### Performance Improvements
+### Performance Improvements
 
 Ember.js 1.9 comes with several performance improvements.
 
@@ -142,7 +142,7 @@ if some work can be skipped.
 Thanks to [@stefanpenner](https://twitter.com/stefanpenner) for his continued
 efforts on performance tuning.
 
-#### Notable Deprecations
+### Notable Deprecations
 
 As Ember.js moves forward, various APIs are deprecated to allow for their
 removal in a later major release (such as 2.0). The
@@ -231,7 +231,7 @@ build pipelines update to support HTMLBars. If you manage a project
 and have any difficulty, reach out to the community and core team
 on the [forum](http://discuss.emberjs.com/) or `#ember-dev` IRC chatroom.
 
-#### Block Params
+### Block Params
 
 Block parameters are a new feature introduced with 1.10. They address
 two problems in Ember:
@@ -284,7 +284,7 @@ car's name.
 
 Many thanks to [@\_mmun](https://twitter.com/_mmun) for the implementation of this important new feature.
 
-#### Renaming Release Files
+### Renaming Release Files
 
 A release of Ember.js consists of three files:
 
@@ -303,7 +303,7 @@ new filename:
 
 An `ember.js` file will continue to be provided with a deprecation warning.
 
-#### Notable Deprecations in 1.10
+### Notable Deprecations in 1.10
 
 The following deprecations are scheduled for release with Ember.js 1.10:
 

--- a/content/ember-1-9-0-released.md
+++ b/content/ember-1-9-0-released.md
@@ -133,11 +133,11 @@ This release introduces `key-up` and `key-down` actions. For example:
 
 Ember.js 1.9 comes with several performance improvements.
 
-* The implementation of `_super` in Ember is fairly complex, and can
+- The implementation of `_super` in Ember is fairly complex, and can
 perform badly. Ember 1.9 uses a check against the string version of a
 function to determine if all parts of the implementation are needed, or
 if some work can be skipped.
-* Additional improvements to the performance of `Ember.Map` have been made.
+- Additional improvements to the performance of `Ember.Map` have been made.
 
 Thanks to [@stefanpenner](https://twitter.com/stefanpenner) for his continued
 efforts on performance tuning.
@@ -236,10 +236,10 @@ on the [forum](http://discuss.emberjs.com/) or `#ember-dev` IRC chatroom.
 Block parameters are a new feature introduced with 1.10. They address
 two problems in Ember:
 
-* The non-context switching version of `{{#each}}` and `{{#with}}` are inconsistent.
+- The non-context switching version of `{{#each}}` and `{{#with}}` are inconsistent.
   `{{#each car in cars}}` and `{{#with model as car}}` have similar meaning but
   different syntaxes.
-* Ember's components are strictly encapsulated. Values are explicitly passed
+- Ember's components are strictly encapsulated. Values are explicitly passed
   in, and only actions are emitted from components. The inability to pass values
   makes composition of components difficult.
 
@@ -288,18 +288,18 @@ Many thanks to [@\_mmun](https://twitter.com/_mmun) for the implementation of th
 
 A release of Ember.js consists of three files:
 
-* `ember.prod.js` - an un-minified production build (no asserts)
-* `ember.min.js` - a minified production build
-* `ember.js` - a development build (with asserts)
+- `ember.prod.js` - an un-minified production build (no asserts)
+- `ember.min.js` - a minified production build
+- `ember.js` - a development build (with asserts)
 
 The non-production build of Ember will not perform as well as the
 production build. To ensure there is no confusion about using the
 `ember.js` build in production, Ember.js 1.10 and later will use a
 new filename:
 
-* `ember.prod.js` - an un-minified production build (no asserts)
-* `ember.min.js` - a minified production build
-* `ember.debug.js` - a development build (with asserts)
+- `ember.prod.js` - an un-minified production build (no asserts)
+- `ember.min.js` - a minified production build
+- `ember.debug.js` - a development build (with asserts)
 
 An `ember.js` file will continue to be provided with a deprecation warning.
 
@@ -307,7 +307,7 @@ An `ember.js` file will continue to be provided with a deprecation warning.
 
 The following deprecations are scheduled for release with Ember.js 1.10:
 
-* Setting the `childViews` property on a view definition will be deprecated in
+- Setting the `childViews` property on a view definition will be deprecated in
   1.10. For example:
 
 ```js
@@ -336,12 +336,12 @@ export default Ember.ContainerView.extend({
 });
 ```
 
-* The `beforeObserver` feature is deprecated in Ember 1.10. Before observers
+- The `beforeObserver` feature is deprecated in Ember 1.10. Before observers
   are rarely used, but introduce significant overhead to the observer system
   in general. For observer use that requires the previous value of a property
   be known, implementing a cache is simple and more efficient. Read more about
   how to do this in [the deprecations page](http://emberjs.com/deprecations/v1.x#toc_deprecate-beforeobservers).
-* Quote-less outlet names are deprecated in 1.10. An example of this is
+- Quote-less outlet names are deprecated in 1.10. An example of this is
   `{{outlet modal}}`, which would be re-written as `{{outlet "modal"}}`.
   This ensures the outlet helper is consistent with others, where unquoted
   words are values and not string literals.
@@ -351,5 +351,5 @@ may be added to the 1.10 release.
 
 ## Changelogs
 
-+ [Ember.js 1.9.0 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.9.0/CHANGELOG.md)
-+ [Ember.js 1.10.0-beta.1 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.10.0-beta.1/CHANGELOG.md)
+- [Ember.js 1.9.0 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.9.0/CHANGELOG.md)
+- [Ember.js 1.10.0-beta.1 CHANGELOG](https://github.com/emberjs/ember.js/blob/v1.10.0-beta.1/CHANGELOG.md)

--- a/content/ember-2-1-beta-released.md
+++ b/content/ember-2-1-beta-released.md
@@ -30,7 +30,7 @@ features will be part of the 2.1 stable version.
 
 A summary of the new features in today's release follows.
 
-#### `{{get}}` Helper
+### `{{get}}` Helper
 
 The `{{get}}` helper allows dynamic property lookup on objects in templates.
 For example, these two usages are equivalent:
@@ -58,7 +58,7 @@ demonstrated how useful this helper would be. Trying his
 [ember-truth-helpers](https://github.com/jmurphyau/ember-truth-helpers) addon
 is highly recommended.
 
-#### `{{each-in}}` Helper
+### `{{each-in}}` Helper
 
 The `{{each-in}}` helper iterates keys and values of an object. It is similar
 conceptually to the `for (key in object) {` syntax of JavaScript. For example,
@@ -84,7 +84,7 @@ Thanks to [@tomdale](https://twitter.com/tomdale) for the
 implementation of this feature, and thanks to
 [@miguelcamba](https://twitter.com/miguelcamba) for his followup PRs.
 
-#### Deprecate and Warn Handlers
+### Deprecate and Warn Handlers
 
 In the run up to Ember 2.0, it became clear that the tooling for management of
 deprecations was poor. One of the reasons for this was the lack of a public,
@@ -141,7 +141,7 @@ Thanks to [@rwjblue](https://twitter.com/rwjblue) for
 shipping this API and the polyfill addon, and to [@mixonic](https://twitter.com/mixonic)
 for the RFC.
 
-#### Registry and Container Reform
+### Registry and Container Reform
 
 The Ember.js registry and container are some of the most extensively used
 private APIs in the framework. They

--- a/content/ember-2-1-released.md
+++ b/content/ember-2-1-released.md
@@ -18,7 +18,7 @@ Ember.js 2.2 beta, the branch of Ember that will be released as stable in roughl
 
 Changes to the Ember's API in 2.1 are backwards compatible. A summary of the new features in today's release follows.
 
-#### `{{get}}` Helper
+### `{{get}}` Helper
 
 The `{{get}}` helper allows dynamic property lookup on objects in templates.
 For example, these two usages are equivalent:
@@ -44,7 +44,7 @@ demonstrated how useful this helper would be. Using his
 [ember-truth-helpers](https://github.com/jmurphyau/ember-truth-helpers) addon
 in 1.13 codebases is highly recommended.
 
-#### `{{each-in}}` Helper
+### `{{each-in}}` Helper
 
 The `{{each-in}}` helper iterates keys and values of an object. It is similar
 conceptually to the `for (key in object) {` syntax of JavaScript. For example,
@@ -69,7 +69,7 @@ Thanks to [@tomdale](https://twitter.com/tomdale) for the
 implementation of this feature, and thanks to
 [@miguelcamba](https://twitter.com/miguelcamba) for his followup PRs.
 
-#### Registry and Container Reform
+### Registry and Container Reform
 
 The Ember.js registry and container are some of the most extensively used
 private APIs in the framework. They
@@ -120,7 +120,7 @@ A huge thanks to the tireless [@dgeb](https://twitter.com/dgeb) for his work on 
 RFC, implementation, and documentation for these changes. They represent a significant
 improvement in Ember's dependency injection system.
 
-#### Deprecate and Warn Handlers
+### Deprecate and Warn Handlers
 
 In the run up to Ember 2.0, it became clear that the tooling for management of
 deprecations was poor. One of the reasons for this was the lack of a public,

--- a/content/ember-2-12-released.md
+++ b/content/ember-2-12-released.md
@@ -169,11 +169,11 @@ The feature also introduces some new errors to rest adapter which will
 be used to reject the adapter promises based on http status of the API
 response.
 
-* [401] `DS.UnauthorizedError`
-* [403] `DS.ForbiddenError`
-* [404] `DS.NotFoundError`
-* [409] `DS.ConflictError`
-* [500] `DS.ServerError`
+- [401] `DS.UnauthorizedError`
+- [403] `DS.ForbiddenError`
+- [404] `DS.NotFoundError`
+- [409] `DS.ConflictError`
+- [500] `DS.ServerError`
 
 Thanks to [tchak](https://github.com/tchak) and
 [twokul](https://github.com/tchak) for their work on this feature and
@@ -244,9 +244,9 @@ Combined, these changes result in a `node_modules` size reduction of approximate
 
 #### Other Notable Changes
 
-* `ember-data` has been removed from the addon blueprint.
-* Properly call `preprocessTree` / `postprocessTree` for addons.
-* Split serving assets into separate internal addons. This enables work to push ember-cli-fastboot towards 1.0.0.
+- `ember-data` has been removed from the addon blueprint.
+- Properly call `preprocessTree` / `postprocessTree` for addons.
+- Split serving assets into separate internal addons. This enables work to push ember-cli-fastboot towards 1.0.0.
 
 For more details on the changes in Ember CLI 2.12 and detailed upgrade
 instructions, please review the [Ember CLI 2.12.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v2.12.0).
@@ -314,9 +314,9 @@ internally, we would like a larger than normal beta testing base to ensure thing
 
 #### Other Notable Changes
 
-* `bower.json` is no longer included in a newly generated project.
-* Fix command interruption issues on windows.
-* Added `filesToRemove` property for custom blueprints.
+- `bower.json` is no longer included in a newly generated project.
+- Fix command interruption issues on windows.
+- Added `filesToRemove` property for custom blueprints.
 
 For more details on the changes in Ember CLI 2.13.0-beta.1 and detailed upgrade
 instructions, please review the [Ember CLI 2.13.0-beta.1 release page](https://github.com/ember-cli/ember-cli/releases/tag/v2.13.0-beta.1).

--- a/content/ember-2-13-released.md
+++ b/content/ember-2-13-released.md
@@ -135,11 +135,11 @@ The feature also introduces some new errors to the REST adapter which will
 be used to reject the adapter promises based on http status of the API
 response.
 
-* [401] `DS.UnauthorizedError`
-* [403] `DS.ForbiddenError`
-* [404] `DS.NotFoundError`
-* [409] `DS.ConflictError`
-* [500] `DS.ServerError`
+- [401] `DS.UnauthorizedError`
+- [403] `DS.ForbiddenError`
+- [404] `DS.NotFoundError`
+- [409] `DS.ConflictError`
+- [500] `DS.ServerError`
 
 Thanks to [tchak](https://github.com/tchak) and
 [twokul](https://github.com/twokul) for their work on this feature and
@@ -243,9 +243,9 @@ npm install --save-dev ember-cli-babel@6
 
 #### Other Notable Changes
 
-* `bower.json` is no longer included in a newly generated project.
-* Fix command interruption issues on windows.
-* Added `filesToRemove` property for custom blueprints.
+- `bower.json` is no longer included in a newly generated project.
+- Fix command interruption issues on windows.
+- Added `filesToRemove` property for custom blueprints.
 
 For more details on the changes in Ember CLI 2.13 and detailed upgrade
 instructions, please review the [Ember CLI 2.13.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v2.13.0).

--- a/content/ember-2-14-released.md
+++ b/content/ember-2-14-released.md
@@ -70,13 +70,13 @@ deprecations.
 
 Two new deprecations are introduces in Ember 2.14.0:
 
-* `Ember.MODEL_FACTORY_INJECTIONS` is deprecated. This flag enabled DI behavior
+- `Ember.MODEL_FACTORY_INJECTIONS` is deprecated. This flag enabled DI behavior
   required by Ember Data prior to changes landed in Ember 2.11. It is intimate
   API scheduled for removal in Ember 2.17.0. If your application sets this
   flag you can safely remove it. See the [deprecation guide
   entry](https://www.emberjs.com/deprecations/v2.x/#toc_ember-model_factory_injections-removed) and the [implementation PR](https://github.com/emberjs/ember.js/pull/15204)
   for more details.
-* Use of the `eventManager` property on components and the `canDispatchToEventManager`
+- Use of the `eventManager` property on components and the `canDispatchToEventManager`
   property on `EventManager`s has been deprecated. These rarely used and
   undocumented parts of the already obscure event manager API where designed for
   touch-event use cases that now have other and better solutions. See the
@@ -93,14 +93,14 @@ For more details on changes in Ember.js 2.14.0, please review the
 
 Ember.js 2.15.0 will introduce two new features:
 
-* [RFC #225](https://github.com/emberjs/rfcs/pull/225) adds the argument
+- [RFC #225](https://github.com/emberjs/rfcs/pull/225) adds the argument
   `model` to the `{{mount}}` engine helper. For example `{{mount 'admin'
   model=(hash user=user)}}` would provide the object with `{user}` as a `model`
   property on the engine's application route. See the [implementation
   PR](https://github.com/emberjs/ember.js/pull/15174) and
   [followup PR](https://github.com/emberjs/ember.js/pull/15325/files) for more
   details.
-* Implementation phase 1 for [RFC #95](https://github.com/emberjs/rfcs/pull/95),
+- Implementation phase 1 for [RFC #95](https://github.com/emberjs/rfcs/pull/95),
   the routing service.
   This RFC describes a first-class
   public API routing service. Amongst other changes, the service provides a way for
@@ -237,16 +237,16 @@ Two other examples of this feature being used in the wild are:
 
 #### Other Notable Changes
 
-+ Node 7.x on Windows is now supported.
-+ By default, Ember CLI collects usage information. Documentation has now been
+- Node 7.x on Windows is now supported.
+- By default, Ember CLI collects usage information. Documentation has now been
 added describing what is collected and who has access to this information.
   See
   [Analytics.md](https://github.com/ember-cli/ember-cli/blob/master/Analytics.md)
   for more information.
-+ A flag `--no-welcome` has been added for `ember new` and `ember init`. Use
+- A flag `--no-welcome` has been added for `ember new` and `ember init`. Use
   this flag to skip the inclusion of `ember-welcome-page` as a dependency in
   newly created projects.
-+ The Ember CLI team recommends Ember Addons use the lowest supported Node release when
+- The Ember CLI team recommends Ember Addons use the lowest supported Node release when
   running CI. As of this release, that means Node 4.x.
 
 For more details on the changes in Ember CLI 2.14.0 and detailed upgrade

--- a/content/ember-2-15-released.md
+++ b/content/ember-2-15-released.md
@@ -58,12 +58,12 @@ into two phases:
 
 **Phase 1** is completed in 2.15.0.
 
-* Implement a public service named `'router'`.
-* Expose the `currentRouteName`,
+- Implement a public service named `'router'`.
+- Expose the `currentRouteName`,
   `currentURL`, `location`, and `rootURL` on the service.
-* Additionally expose
+- Additionally expose
   `transitionTo` and `replaceWith` as methods on the service.
-* Provide the method `urlFor` to the service for generating URLs based on a
+- Provide the method `urlFor` to the service for generating URLs based on a
   route name and models.
 
 An example of this API would be to transition to another route from a
@@ -93,9 +93,9 @@ documentation](https://www.emberjs.com/api/ember/2.15/classes/RouterService).
 **Phase 2** is pending implementation of the new public `RouteInfo` API. It is
 not included in Ember 2.15.0.
 
-* Expand the service with the methods `isActive`, `recognize`, and
+- Expand the service with the methods `isActive`, `recognize`, and
   `recognizeAndLoad`.
-* Deprecate the `willTransition` and `didTransition` router hooks (not the
+- Deprecate the `willTransition` and `didTransition` router hooks (not the
   route actions of the same name). Replace them with events emitted by the
   router service which have improved timing and public API arguments:
   `routeWillChange` and `routeDidChange`.
@@ -137,13 +137,13 @@ And in an engine access those values on the `model` property:
 
 Other changes include:
 
-* Ember 2.15.0 blueprints will no longer generate names for initializers and
+- Ember 2.15.0 blueprints will no longer generate names for initializers and
   instance initializers.
-* The deprecated API `_lookupFactory` has been removed in this release. See
+- The deprecated API `_lookupFactory` has been removed in this release. See
   the [deprecation
   guide](https://www.emberjs.com/deprecations/v2.x/#toc_migrating-from-_lookupfactory-to-factoryfor)
   for details about moving away from this API.
-* The Glimmer-VM rendering engine has been updated in this release, matching
+- The Glimmer-VM rendering engine has been updated in this release, matching
   Ember's rendering engine to that of the Glimmer.js library at its EmberConf
   release. Included are VM improvement such as the "stack VM", improved
   assertion stripping in production builds, and a more complete Glimmer-VM
@@ -198,9 +198,9 @@ To help us test the migration path, existing applications can move to adopt
 the new import style immediately. Using 2.16-beta of Ember is suggested, but
 not actually required. To update an application:
 
-* Upgrade ember-cli-babel to v6.8.0 or greater. This may require you to upgrade
+- Upgrade ember-cli-babel to v6.8.0 or greater. This may require you to upgrade
   ember-cli generally depending on your current version.
-* Install and run the
+- Install and run the
   [ember-modules-codemod](https://github.com/ember-cli/ember-modules-codemod).
   This command will migrate legacy code that imports the `'ember'` package to
   the new modules, updating files in place.
@@ -226,16 +226,16 @@ package provides a linting rule that can remove usage of the legacy modules
 provided by ember-cli-shims.
 To run this follow these steps:
 
-* Install eslint-plugin-ember v4.3.0 or greater as a dev dependency for your
+- Install eslint-plugin-ember v4.3.0 or greater as a dev dependency for your
   application.
-* Follow the eslint-plugin-ember
+- Follow the eslint-plugin-ember
   [usage instructions](https://github.com/ember-cli/eslint-plugin-ember#-usage)
   and update your `.eslintrc.js` appropriately.
   For more detailed instructions, see this excellent blog post:
   [How To Use Ember’s New Module Import Syntax Today](https://medium.com/@Dhaulagiri/embers-javascript-modules-api-b4483782f329)
-* Run `./node_modules/.bin/eslint --fix` to convert ember-cli-shims module usage to plain `'ember'`
+- Run `./node_modules/.bin/eslint --fix` to convert ember-cli-shims module usage to plain `'ember'`
   imports.
-* Run the ember-modules-codemod as described above.
+- Run the ember-modules-codemod as described above.
 
 By trying these migration steps on your applications, you can provide valuable
 feeback to improve the final process announced with 2.16.
@@ -245,9 +245,9 @@ feeback to improve the final process announced with 2.16.
 To prepare your addons for Ember 2.16, we encourage you to take the following
 steps during the beta cycle:
 
-* Upgrade your ember-cli-babel dependency to v6.8.0. This will permit your addon
+- Upgrade your ember-cli-babel dependency to v6.8.0. This will permit your addon
   to use the new modules in the `addon/` and `test/` directories.
-* Ensure the `app/` and `test-support/` directories (both part of the dependent
+- Ensure the `app/` and `test-support/` directories (both part of the dependent
   app's build) contain only re-exports.
 
 This will ensure applications have a path forward in 2.16 to drop
@@ -260,7 +260,7 @@ Community Slack](https://embercommunity.slack.com/messages/C045BNHAP/).
 
 One new deprecation is introduced in Ember.js 2.16-beta:
 
-* For historical reasons, Ember controllers have a private property `content`
+- For historical reasons, Ember controllers have a private property `content`
   that aliases the `model` property. Relying on this legacy behavior is
   deprecated and will be unsupported in Ember 2.17. See the
   [deprecation guide](https://www.emberjs.com/deprecations/v2.x/#toc_controller-content-alias)

--- a/content/ember-2018-roadmap-call-for-posts.md
+++ b/content/ember-2018-roadmap-call-for-posts.md
@@ -25,7 +25,7 @@ The Roadmap will outline the community's priorities for the remainder of the yea
 
 To contribute a post: Tweet a link to the post with the hashtag [#EmberJS2018](https://twitter.com/hashtag/emberjs2018) or, if you're not on Twitter, email a link to `roadmap@emberjs.com`. These posts will be collected and categorized, and each one will be read by those working to draft the Roadmap RFC. 
 
-#### Format
+### Format
 
 Your post can be on any online writing platform, but we suggest:
 
@@ -33,7 +33,7 @@ Your post can be on any online writing platform, but we suggest:
 * A [Medium](https://medium.com/) post
 * A [GitHub gist](https://gist.github.com/)
 
-#### Topic Ideas
+### Topic Ideas
 
 We'd like to hear about any aspect of Ember you have hopes for in 2018--not just about the Ember.js framework. Please include your desires for Ember Data, Ember CLI, tooling, the community, addons, and anything else Ember-related.
 
@@ -52,7 +52,7 @@ To kickoff the process, we've collected some early posts:
 * [Blog Post for an Ambitious Framework](https://blog.201-created.com/blog-post-for-an-ambitious-framework-d7e9248893fa) by Matthew Beale and the [201 Created](https://www.201-created.com/) team
 * [Wishing on a Star](https://medium.com/@melaniesumner/wishing-on-a-star-722a4fe590a7) by Melanie Sumner 
 
-#### Preliminary Timeline
+### Preliminary Timeline
 
 Dates may change, but this is a general overview of the upcoming process:
 

--- a/content/ember-3-1-released.md
+++ b/content/ember-3-1-released.md
@@ -317,17 +317,17 @@ Ember Data 3.1 contains bug fixes and build improvements for Ember Data.
 
 **Two** new deprecations are introduced in Ember Data 3.1.
 
-* `Ember.Map` was a private API provided by Ember (for quite some time). Unfortunately, Ember Data made `Ember.Map` part of its public API surface via documentation blocks. `Ember.Map` is [scheduled for deprecation](scheduled for deprecation), after we make sure that Ember Data will continue working after this feature is deprecated and removed.`Ember.Map` differs from native `Map` in a few ways:
-    * `Ember.Map` has custom `copy` and `isEmpty` methods which are not present in native `Map`
-    * `Ember.Map` adds a static `create` method (which simply instantiates itself with `new Ember.Map()`)
-    * `Ember.Map` does not accept constructor arguments
-    * `Ember.Map` does not have:
-      * `@@species`
-      * `@@iterator`
-      * `entries`
-      * `values` This implementation adds a deprecated backwards compatibility for:
-          * `copy`
-          * `isEmpty`
+- `Ember.Map` was a private API provided by Ember (for quite some time). Unfortunately, Ember Data made `Ember.Map` part of its public API surface via documentation blocks. `Ember.Map` is [scheduled for deprecation](scheduled for deprecation), after we make sure that Ember Data will continue working after this feature is deprecated and removed.`Ember.Map` differs from native `Map` in a few ways:
+    - `Ember.Map` has custom `copy` and `isEmpty` methods which are not present in native `Map`
+    - `Ember.Map` adds a static `create` method (which simply instantiates itself with `new Ember.Map()`)
+    - `Ember.Map` does not accept constructor arguments
+    - `Ember.Map` does not have:
+      - `@@species`
+      - `@@iterator`
+      - `entries`
+      - `values` This implementation adds a deprecated backwards compatibility for:
+          - `copy`
+          - `isEmpty`
 
 This is needed because `Map` requires instantiation with `new`, and by default Babel transpilation will do `superConstructor.apply(this, arguments)` which throws an error with native `Map`. The desired code (if we lived in an "only native class" world) would be:
 

--- a/content/ember-3-6-released.md
+++ b/content/ember-3-6-released.md
@@ -60,11 +60,11 @@ For users who aren't ready to adopt, that's OK - the EmberObject model will cont
 
 There are a few notable changes and features for native classes:
 
-* `new` syntax is not currently supported with classes that extend from `EmberObject`. You must continue to use the `create` method when making new instances of classes, even if they are defined using native class syntax. If you want to use `new` syntax, consider creating classes which do _not_ extend from `EmberObject`. Ember features, such as computed properties and decorators, will still work with base-less classes.
-* Instead of using `this._super()`, you must use standard `super` syntax. See the [MDN docs on classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#Super_class_calls_with_super) for more details.
-* Native classes support using [constructors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#Constructor) to set up newly-created instances. Ember uses these to, among other things, support features that need to retrieve other entities by name, like Service injection and `getOwner`. To ensure your custom instance setup logic takes place after this important work is done, avoid using the `constructor` in favor of `init`.
-* Using native classes, and switching back to the old Ember Object model is fully supported.
-* For early adopters who are used to argument values and values passed to `create` being overriden, this is no longer the case! Class field values will be the default, and any value passed to a class on creation will override that value.
+- `new` syntax is not currently supported with classes that extend from `EmberObject`. You must continue to use the `create` method when making new instances of classes, even if they are defined using native class syntax. If you want to use `new` syntax, consider creating classes which do _not_ extend from `EmberObject`. Ember features, such as computed properties and decorators, will still work with base-less classes.
+- Instead of using `this._super()`, you must use standard `super` syntax. See the [MDN docs on classes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#Super_class_calls_with_super) for more details.
+- Native classes support using [constructors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#Constructor) to set up newly-created instances. Ember uses these to, among other things, support features that need to retrieve other entities by name, like Service injection and `getOwner`. To ensure your custom instance setup logic takes place after this important work is done, avoid using the `constructor` in favor of `init`.
+- Using native classes, and switching back to the old Ember Object model is fully supported.
+- For early adopters who are used to argument values and values passed to `create` being overriden, this is no longer the case! Class field values will be the default, and any value passed to a class on creation will override that value.
 
 **Compatibility and Polyfill**
 
@@ -98,11 +98,11 @@ For more details on changes in Ember.js 3.6, please review the [Ember.js 3.6 rel
 
 We are deprecating usage of `new EmberObject()` to construct instances of `EmberObject` and its subclasses. This affects all classes that extend from `EmberObject` as well, including user defined classes and Ember classes such as:
 
-* `Component`
-* `Controller`
-* `Service`
-* `Route`
-* `Model`
+- `Component`
+- `Controller`
+- `Service`
+- `Route`
+- `Model`
 
 Instead, you should use `EmberObject.create()` to create new instances of classes that extend from `EmberObject`. If you are using native class syntax instead of `EmberObject.extend()` to define your classes, you can also refactor to _not_ extend from `EmberObject`, and continue to use `new` syntax.
 

--- a/content/ember-data-1-0-beta-16-released.md
+++ b/content/ember-data-1-0-beta-16-released.md
@@ -125,7 +125,7 @@ In addition to the major changes mentioned above this release also
 includes many bug fixes and documentation updates. Be sure to check
 out the change log for the full list of updates.
 
-+ [Ember Data 1.0.0-beta.16 CHANGELOG](https://github.com/emberjs/data/blob/v1.0.0-beta.16/CHANGELOG.md)
+- [Ember Data 1.0.0-beta.16 CHANGELOG](https://github.com/emberjs/data/blob/v1.0.0-beta.16/CHANGELOG.md)
 
 
 <!-- Links -->

--- a/content/ember-data-1-13-released.md
+++ b/content/ember-data-1-13-released.md
@@ -21,7 +21,7 @@ blog post, going forward Ember Data will be syncing up its releases and version 
 **Ember Data 1.13 is the first release of Ember Data that syncs its
   version with a version of Ember.js.** It will be followed by Ember Data 2.0, which will be released alongside Ember.js 2.0. **Ember Data 1.13 is fully backwards compatible with Ember Data beta.19, allowing for a smooth upgrade path.**
 
-### Ember Data 1.13 Overview
+## Ember Data 1.13 Overview
 
 Ember Data 1.13 is a massive release we are very proud of.
 The highlight of the Ember Data 1.13 release is a total overhaul of Ember Data's internal format and Serializer API to follow JSON API. 
@@ -109,7 +109,7 @@ as static files at [http://emberjs.com/builds]().
 
 ## New Features
 
-## Simplified Find Methods
+### Simplified Find Methods
 
 Ember Data methods on the store have grown organically over the life
 of the project. Originally, Ember Data started with `store.find(type)`
@@ -128,7 +128,7 @@ In particular, `store.find`, `store.all`, `store.getById` have been
 deprecated and are replaced with consistently named methods. New methods follow a simple convention: If they are async and potentially go to the server, they start with `find`, and if they only get store local data without side-effects they start with `peek`.
 If they return a single record they end in `Record` and if they return all the records they end in `All` .
 
-#### Reorganized Find Methods
+### Reorganized Find Methods
 
 <table>
   <thead>
@@ -157,7 +157,7 @@ If they return a single record they end in `Record` and if they return all the r
 
 \* A query usually does not return all the records of a type, so doesn't end in `All`.
 
-#### query and queryRecord
+### query and queryRecord
 
 The final use case for the old `store.find` method was issuing queries
 to the server. This usage of `store.find(type, { query })` has been
@@ -252,7 +252,7 @@ store.findAll('user');  //after that returns from cache, but updates in backgrou
 store.findAll('user', { reload: true });  //enforces getting fresh data
 ```
 
-#### `fetchById` and `fetchAll` Replaced by `findRecord` and `findAll`
+### `fetchById` and `fetchAll` Replaced by `findRecord` and `findAll`
 
 Having these two methods, with customizable flags allows us to get rid of:
 `store.fetchById` and `store.fetchAll`.

--- a/content/ember-data-2-5-released.md
+++ b/content/ember-data-2-5-released.md
@@ -48,10 +48,10 @@ in [RFC 57](https://github.com/emberjs/rfcs/pull/57). References is a
 low level API to perform meta-operations on records, has-many
 relationships and belongs-to relationships:
 
-  * get the current local data synchronously without triggering a fetch or producing a promise
-  * notify the store that a fetch for a given record has begun, and provide a promise for its result
-  * similarly, notify a record that a fetch for a given relationship has begun, and provide a promise for its result
-  * retrieve server-provided metadata about a record or relationship
+  - get the current local data synchronously without triggering a fetch or producing a promise
+  - notify the store that a fetch for a given record has begun, and provide a promise for its result
+  - similarly, notify a record that a fetch for a given relationship has begun, and provide a promise for its result
+  - retrieve server-provided metadata about a record or relationship
 
 Consider the following `post` model:
 

--- a/content/security-and-bugfix-releases-ember-1-10-1-1-11-2-1-11-3.md
+++ b/content/security-and-bugfix-releases-ember-1-10-1-1-11-2-1-11-3.md
@@ -46,7 +46,7 @@ our [security announcements mailing
 list](https://groups.google.com/forum/#!forum/ember-security).  It is
 extremely low-traffic and only contains announcements such as these.
 
-#### Additional Reading
+### Additional Reading
 
 * [Ember.js Security Policy Announcement](/blog/2013/04/05/announcing-the-ember-security-policy.html)
 * [Ember.js Security Policy](/security/)

--- a/content/security-incident-aws-s3-key-exposure.md
+++ b/content/security-incident-aws-s3-key-exposure.md
@@ -68,6 +68,6 @@ If you discover a security-related issue in Ember, we ask that you follow our [d
 
 #### Additional Reading
 
-* [Ember.js Security Policy Announcement](/blog/2013/04/05/announcing-the-ember-security-policy.html)
-* [Ember.js Security Policy](/security/)
-* [Ember.js Security Mailing List](https://groups.google.com/forum/#!forum/ember-security)
+- [Ember.js Security Policy Announcement](/blog/2013/04/05/announcing-the-ember-security-policy.html)
+- [Ember.js Security Policy](/security/)
+- [Ember.js Security Mailing List](https://groups.google.com/forum/#!forum/ember-security)

--- a/content/security-releases-ember-1-11-4-1-12-2-1-13-12-2-0-3-2-1-2-2-2-1.md
+++ b/content/security-releases-ember-1-11-4-1-12-2-1-13-12-2-0-3-2-1-2-2-2-1.md
@@ -50,7 +50,7 @@ our [security announcements mailing
 list](https://groups.google.com/forum/#!forum/ember-security).  It is
 extremely low-traffic and only contains announcements such as these.
 
-#### Additional Reading
+### Additional Reading
 
 * [Ember.js Security Policy Announcement](/blog/2013/04/05/announcing-the-ember-security-policy.html)
 * [Ember.js Security Policy](/security/)

--- a/content/the-ember-times-issue-63.md
+++ b/content/the-ember-times-issue-63.md
@@ -37,9 +37,9 @@ The Ember Data team is looking for community help to bring RecordData to a stabl
 
 Community action items:
 
-* Once [3.5.0-beta.2](https://github.com/emberjs/data/pull/5616) is released, configure your apps/addons to test against this version!
-* Report errors encountered, and help triage/replicate as much as possible.
-* Help refactor existing addons to utilize RecordData instead of likely-removed intimate APIs. For a good starter list, see Ember Data's [external-partner tests](https://github.com/emberjs/data/blob/master/.travis.yml#L87-L103).
+- Once [3.5.0-beta.2](https://github.com/emberjs/data/pull/5616) is released, configure your apps/addons to test against this version!
+- Report errors encountered, and help triage/replicate as much as possible.
+- Help refactor existing addons to utilize RecordData instead of likely-removed intimate APIs. For a good starter list, see Ember Data's [external-partner tests](https://github.com/emberjs/data/blob/master/.travis.yml#L87-L103).
 
 ---
 
@@ -48,10 +48,10 @@ Community action items:
 
 The benefit of this being that this gives the Ember Community an opportunity to bring our documentation and marketing up-to-date to reflect the improvements we’ve made since the previous edition. According to the RFC, the right time to declare a new edition is when:
 
-* A significant, coherent set of new features and APIs have all landed in the stable channel.
-* Error messages and the developer ergonomics of those new features have been fully polished.
-* Tooling (the Ember Inspector, blueprints, codemods, etc.) has been updated to work with these new features.
-* API documentation, guides, tutorials, and example code has been updated to incorporate the new features.
+- A significant, coherent set of new features and APIs have all landed in the stable channel.
+- Error messages and the developer ergonomics of those new features have been fully polished.
+- Tooling (the Ember Inspector, blueprints, codemods, etc.) has been updated to work with these new features.
+- API documentation, guides, tutorials, and example code has been updated to incorporate the new features.
 
 Make sure to [read the entire RFC](https://github.com/emberjs/rfcs/blob/9c7fe3f4e947b5f79050214334a98673494c25d7/text/0000-editions.md) and [leave a comment with your thoughts](https://github.com/emberjs/rfcs/pull/371).
 

--- a/content/the-ember-times-issue-93.md
+++ b/content/the-ember-times-issue-93.md
@@ -85,13 +85,13 @@ But it can be **challenging** to sway folks outside of the community to Ember. F
 
 This quote reminded us of our past Readers’ Question from [@kategengler](https://github.com/kategengler), where she discussed ["How do I pitch Ember at my company?"](https://discuss.emberjs.com/t/readers-questions-how-do-i-pitch-ember-at-my-company/14289) We thought it would be worthwhile to share some of her tips again:
 
-* Ember is used by large corporations such as LinkedIn, Intercom, Discourse, Sentry, and others.
-* Everything you need is included out-of-the-box (router, data layer, build tool), but there’s also the flexibility to replace pieces if needed.
-* There are many high-quality community-contributed/maintained addons. There are well-established solutions for common needs such as deployment, internationalization, accessibility, user interface elements, etc. See more at [emberobserver.com](https://emberobserver.com/).
-* Ember CLI makes it simple to get a local development environment going.
-* LTS releases ensure you don’t have to constantly update Ember to get bug and security fixes.
-* Ember evolves without making sudden breaking changes. API changes are signaled well in advance of a major version through deprecations, with the major versions merely removing those deprecated APIs.
-* The Ember community is active, helpful, and easy to find in the [Ember Community on Discord](https://discordapp.com/invite/zT3asNS).
+- Ember is used by large corporations such as LinkedIn, Intercom, Discourse, Sentry, and others.
+- Everything you need is included out-of-the-box (router, data layer, build tool), but there’s also the flexibility to replace pieces if needed.
+- There are many high-quality community-contributed/maintained addons. There are well-established solutions for common needs such as deployment, internationalization, accessibility, user interface elements, etc. See more at [emberobserver.com](https://emberobserver.com/).
+- Ember CLI makes it simple to get a local development environment going.
+- LTS releases ensure you don’t have to constantly update Ember to get bug and security fixes.
+- Ember evolves without making sudden breaking changes. API changes are signaled well in advance of a major version through deprecations, with the major versions merely removing those deprecated APIs.
+- The Ember community is active, helpful, and easy to find in the [Ember Community on Discord](https://discordapp.com/invite/zT3asNS).
 
 ---
 

--- a/content/the-ember-times-issue-94.md
+++ b/content/the-ember-times-issue-94.md
@@ -133,9 +133,9 @@ Looking for some more Ember content to watch? The first batch of EmberCamp 2018 
 
 We especially enjoyed [@toranb](https://github.com/toranb)'s talk [Fast Feedback, Forward Progress](https://www.youtube.com/watch?v=wX8PxE0BVjI&list=PL4eq2DPpyBbm-vTgHMdBjUi1Qd5GiRIfW&index=4) where he talks about ways to **work smarter, not harder** as developers. He shares ways to choose productivity with a few stories in Ember.
 
-* Test driven development: Choose a feedback loop designed for experimentation and learning
-* Hot reloading: Choose a feedback loop designed with layout in mind
-* User experience: Choose a feedback loop your customers will love
+- Test driven development: Choose a feedback loop designed for experimentation and learning
+- Hot reloading: Choose a feedback loop designed with layout in mind
+- User experience: Choose a feedback loop your customers will love
 
 Stay tuned for future announcements by following [@embercamp](https://twitter.com/embercamp) on Twitter. And **save the date**, EmberCamp Chicago 2019 will be on August 23rd.
 


### PR DESCRIPTION
## Description

Related issue: https://github.com/ember-learn/ember-blog/issues/851

I enabled 3 rules in `markdownlint`:

- MD001
- MD003
- MD004