### PR TITLE
Fixed lint errors from markdownlint (Part 2)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -8,7 +8,6 @@
   "no-trailing-spaces": false,
   "no-multiple-blanks": false,
   "MD007": { "indent": 4 },
-  "MD018": false,
   "MD022": false,
   "MD025": false,
   "MD028": false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -8,7 +8,6 @@
   "no-trailing-spaces": false,
   "no-multiple-blanks": false,
   "MD007": { "indent": 4 },
-  "MD011": false,
   "MD018": false,
   "MD022": false,
   "MD025": false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -7,7 +7,6 @@
   "no-trailing-punctuation": false,
   "no-trailing-spaces": false,
   "no-multiple-blanks": false,
-  "MD005": false,
   "MD007": false,
   "MD010": false,
   "MD011": false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -8,7 +8,6 @@
   "no-trailing-spaces": false,
   "no-multiple-blanks": false,
   "MD007": { "indent": 4 },
-  "MD010": false,
   "MD011": false,
   "MD018": false,
   "MD022": false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -7,7 +7,7 @@
   "no-trailing-punctuation": false,
   "no-trailing-spaces": false,
   "no-multiple-blanks": false,
-  "MD007": false,
+  "MD007": { "indent": 4 },
   "MD010": false,
   "MD011": false,
   "MD018": false,

--- a/content/core-team-meeting-minutes-2013-12-06.md
+++ b/content/core-team-meeting-minutes-2013-12-06.md
@@ -34,8 +34,8 @@ public, we'll be posting notes from these meetings.
 
 Resolutions:
 
-  * @trek publish core team meeting notes
-  * @trek post weekly reminders that the core team meeting occurs and invite people
+* @trek publish core team meeting notes
+* @trek post weekly reminders that the core team meeting occurs and invite people
     to contact individual core team members if they have issued they’d like raised.
 
 #### HTMLBars
@@ -43,7 +43,7 @@ Resolutions:
 
 Resolutions:
   
-  * @krisselden will come a bit early to the face to face to get mind-dumped. @machty
+* @krisselden will come a bit early to the face to face to get mind-dumped. @machty
     is already familiar with writing Handlebars runtime compatible template languages
     from his work on [Emblem.js](http://emblemjs.com/) so can also help get this
     over the last few hurdles.

--- a/content/core-team-meeting-minutes-2013-12-20.md
+++ b/content/core-team-meeting-minutes-2013-12-20.md
@@ -36,8 +36,8 @@ try it, and offer feedback.
 
 Resolutions:
   
-  * @trek will start working on docs.
-  * @tomdale, @wycats will publish an ember data update blog post.
+* @trek will start working on docs.
+* @tomdale, @wycats will publish an ember data update blog post.
 
 #### Query Params
 Some debate about the correct location for defining and handling query parameters
@@ -45,7 +45,7 @@ Some debate about the correct location for defining and handling query parameter
 
 Resolutions:
   
-  * a smaller group will handle that discussion
+* a smaller group will handle that discussion
 
 #### Pods
 During the face-to-face we floated the idea of organizing an application's files in a
@@ -55,4 +55,4 @@ this structure.
 
 Resolutions:
     
-  * @trek will reach out to people said they've built in this style.
+* @trek will reach out to people said they've built in this style.

--- a/content/core-team-meeting-minutes-2014-01-03.md
+++ b/content/core-team-meeting-minutes-2014-01-03.md
@@ -28,23 +28,23 @@ gives a "go" or "no-go" vote to feature-flagged beta functionality.
 
 #### query-params-new: no-go
 
-  * needs more people trying this
-  * doc/guides need to be updated.
+* needs more people trying this
+* doc/guides need to be updated.
 
 #### with-controller: go
 
-  * make sure to add parentController immediately after merge (@kselden)
-  * address https://github.com/emberjs/ember.js/issues/4050 (@stefanpenner)
-  * ensure lookupFactory and creates with content
+* make sure to add parentController immediately after merge (@kselden)
+* address https://github.com/emberjs/ember.js/issues/4050 (@stefanpenner)
+* ensure lookupFactory and creates with content
     ```
     {{#with foo controller=’someController}}
     ```
 
 #### ember-metal-with-proxy: go
 
-  * rename to Ember.run.bind and merge (@stefanpenner)
+* rename to Ember.run.bind and merge (@stefanpenner)
 
 #### ember-metal-run-method: no-go
 
-  * @krisselden and @wycats are worried that this will be used inappropriately
-  * people should use `.run` at the root of a frame, not randomly throughout it
+* @krisselden and @wycats are worried that this will be used inappropriately
+* people should use `.run` at the root of a frame, not randomly throughout it

--- a/content/core-team-meeting-minutes-2014-01-17.md
+++ b/content/core-team-meeting-minutes-2014-01-17.md
@@ -38,10 +38,10 @@ can be found on this Github issue:
 The following features look good in their current incarnation and will likely receive a "go"
 vote:
 
-  * [ember-testing-routing-helpers](https://github.com/emberjs/ember.js/pull/3711)
-  * [computed-read-only](https://github.com/emberjs/ember.js/pull/3879)
-  * [ember-metal-is-blank](https://github.com/emberjs/ember.js/pull/4049)
-  * [ember-eager-url-update](https://github.com/emberjs/ember.js/pull/4122)
+* [ember-testing-routing-helpers](https://github.com/emberjs/ember.js/pull/3711)
+* [computed-read-only](https://github.com/emberjs/ember.js/pull/3879)
+* [ember-metal-is-blank](https://github.com/emberjs/ember.js/pull/4049)
+* [ember-eager-url-update](https://github.com/emberjs/ember.js/pull/4122)
 
 #### [string-humanize](https://github.com/emberjs/ember.js/pull/3224) and [string-parameterize](https://github.com/emberjs/ember.js/pull/3953)
 There is a concern that this increases the surface area of API and the size of the framework
@@ -53,7 +53,7 @@ and the common case is already handled by existing libraries.
 
 Resolutions:
   
-  * Revert.
+* Revert.
 
 
 #### [ember-handlebars-caps-lookup](https://github.com/emberjs/ember.js/pull/3218)
@@ -64,25 +64,25 @@ issues for people who used this as part of their app design.
   
 Some proposed ideas:
 
-  * try local lookup first
-  * try global lookup and issue a deprecation warning ("will be removed in 2.0")
+* try local lookup first
+* try global lookup and issue a deprecation warning ("will be removed in 2.0")
 
 Resolutions:
   
-  * Revert.
-  * @wycats will talk to the author about a revert and our preferred way forward for this
+* Revert.
+* @wycats will talk to the author about a revert and our preferred way forward for this
     behavior
 
 #### [ember-testing-triggerEvent-helper](https://github.com/emberjs/ember.js/pull/3792)
 
 Looks good but needs some revision:
 
-  * Needs mechanism for customizing event with additional data (i.e. which key is being pressed)
-  * Possibly have `keyEvent` event helper use `triggerEvent` internally
+* Needs mechanism for customizing event with additional data (i.e. which key is being pressed)
+* Possibly have `keyEvent` event helper use `triggerEvent` internally
 
 Resolutions:
 
-  * @ebryn will provide feedback on the PR
+* @ebryn will provide feedback on the PR
 
 #### [composable-computed-properties](https://github.com/emberjs/ember.js/pull/3696)
 Possibly still needs some work (there some unhandled todos)? Will be a "go" when
@@ -90,7 +90,7 @@ these are addressed.
 
 Resolutions:
 
-  * @trek will ask about the status of remaining todos
+* @trek will ask about the status of remaining todos
 
 #### [query-params-new](https://github.com/emberjs/ember.js/pull/4008)
 @wycats and @machty chatted about some last minute issues. This PR should be good soon.
@@ -99,7 +99,7 @@ happens if two controllers in same hierarchy have the same parameter name).
 
 Resolutions:
 
-  * @machty will keep chugging along
+* @machty will keep chugging along
 
 
 #### [ember-routing-loading-error-substates](https://github.com/emberjs/ember.js/pull/3655)

--- a/content/core-team-meeting-minutes-2014-01-27.md
+++ b/content/core-team-meeting-minutes-2014-01-27.md
@@ -30,7 +30,7 @@ due to the Google outage that affected Google Hangouts.
 #### Issues Discussion:
 The core team discussed the following Github Issues
 
-  * `ember-routing-auto-location` [#3725](https://github.com/emberjs/ember.js/pull/3725).
+* `ember-routing-auto-location` [#3725](https://github.com/emberjs/ember.js/pull/3725).
 
     resolution:
 
@@ -41,7 +41,7 @@ The core team discussed the following Github Issues
     * document that backend support is needed and that your app will not have 
       canonical URLs (i.e. every URL will have two versions in the wild: `/#/foo` and `/foo`)
 
-  * Bound Action Lookup [#3936](https://github.com/emberjs/ember.js/pull/3936)
+* Bound Action Lookup [#3936](https://github.com/emberjs/ember.js/pull/3936)
 
     We added default fall back to allow a static string action name if a property isn't found,
     but it is possible that this will break things if you have a property AND an action named
@@ -51,7 +51,7 @@ The core team discussed the following Github Issues
 
     resolution: Ensure docs are updated so unquoted style is not used before shipping.
 
-  * `ember-views-bindable-attributes` [#4170](https://github.com/emberjs/ember.js/pull/4170)
+* `ember-views-bindable-attributes` [#4170](https://github.com/emberjs/ember.js/pull/4170)
 
     We like the idea generally but there are doubts having a a separate API, we should explore pushing it into a single API. Differences between this and `attributeBindings` are too subtle, we should not fragment
 
@@ -60,19 +60,19 @@ The core team discussed the following Github Issues
     resolution: @ebryn will talk to Robert
 
 
-  * Replace `module` with *something* else. [#3838](https://github.com/emberjs/ember.js/pull/3838)
+* Replace `module` with *something* else. [#3838](https://github.com/emberjs/ember.js/pull/3838)
   
     This is due to an issue under Node (since `module` is a reserved word). It ultimately doesn't matter what we decide on, but if we want the test suite to run under Node (for `ember-runtime` and `ember-metal` specifically, but also possibly `ember-data`) we need to use something that isn't a keyword.
 
     resolution: QUnit.module, but check for prior art. (@stefanpenner)
 
-  * Update Backburner (and Docs). [#4120](https://github.com/emberjs/ember.js/pull/4120)
+* Update Backburner (and Docs). [#4120](https://github.com/emberjs/ember.js/pull/4120)
 
     Contains potentially breaking change to `throttle` to default to running immediately (from [ebryn/backburner.js#55](https://github.com/ebryn/backburner.js/pull/55) ).
    
     resolution: it was a bug, breaking it is fine.
 
-  * [https://github.com/emberjs/ember.js/issues/3256](https://github.com/emberjs/ember.js/issues/3256)
+* [https://github.com/emberjs/ember.js/issues/3256](https://github.com/emberjs/ember.js/issues/3256)
   
     resolution: bindingPaths to globals should be canned, so we won't support additional features built on
     on this behavior.

--- a/content/core-team-meeting-minutes-2014-01-31.md
+++ b/content/core-team-meeting-minutes-2014-01-31.md
@@ -24,7 +24,7 @@ core team member and let them know!
 
 ### Go/No-Go Feature Listing
 
-  * `ember-routing-named-substates` [#3655](https://github.com/emberjs/ember.js/pull/3655)
+* `ember-routing-named-substates` [#3655](https://github.com/emberjs/ember.js/pull/3655)
       @krisselden: likes the feature a lot (we should “just doit”)
       @wycats: naming with globals is totally unsolvable.
       @machty: If FooLoading is ambiguous, we should just warn that global mode is not supported for this feature
@@ -33,36 +33,36 @@ core team member and let them know!
       resolution: Tom and Stef will review
 
 
-  * `ember-handlebars-caps-lookup` [#3218](https://github.com/emberjs/ember.js/pull/3218)
+* `ember-handlebars-caps-lookup` [#3218](https://github.com/emberjs/ember.js/pull/3218)
 
       resolution: check local first, warn and fallback to global seems like a good strategy
 
-  * `ember-testing-simple-setup` [#3785](https://github.com/emberjs/ember.js/pull/3785)
+* `ember-testing-simple-setup` [#3785](https://github.com/emberjs/ember.js/pull/3785)
 
       resolution: Tom and Stef will review
 
-  * `version api docs`
+* `version api docs`
 
     Often asked for. We should work with community, see if robert can own, and help delegate.
 
-  * `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
+* `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
 
     misleading bug reports, but eager loader of controllers was the original pain point that kept
     this a "No go"
 
 
-  *  `composable-computed-properties` [#3696](https://github.com/emberjs/ember.js/pull/3696)
+*  `composable-computed-properties` [#3696](https://github.com/emberjs/ember.js/pull/3696)
 
     @wycats: aliased to short words in the examples, should be documented to match this?
     @ebryn:: new CP work may have issues, @wycats and @ebryn and David should talk.
 
     resolution: @ebryn will talk to David about blocking
 
-  * `ember-routing-auto-location` [#3725](https://github.com/emberjs/ember.js/pull/3725)
+* `ember-routing-auto-location` [#3725](https://github.com/emberjs/ember.js/pull/3725)
 
      resolution: Alex will make sure docs are good, then this becomes a "Go"
 
-  * `ember-routing-bound-action-name` [#3936](https://github.com/emberjs/ember.js/pull/3936)
+* `ember-routing-bound-action-name` [#3936](https://github.com/emberjs/ember.js/pull/3936)
 
     resolution: "Go" but we need an intermediate release issuing deprecation warnings, a future release will have break. This future release may contain some helpful warning, and the release notes will contain this info.
 

--- a/content/core-team-meeting-minutes-2014-02-07.md
+++ b/content/core-team-meeting-minutes-2014-02-07.md
@@ -27,66 +27,66 @@ core team member and let them know!
 #### Features pending 'Go' decision.
 The core team reviewed the following pull requests for inclusion in the 1.5.x beta series:
 
-  * `ember-routing-named-substates` [#3655](https://github.com/emberjs/ember.js/pull/3655)
+* `ember-routing-named-substates` [#3655](https://github.com/emberjs/ember.js/pull/3655)
 
     Tom and Stef still need to discuss how to handle module mode + new semantics next week.
 
     Resolution: Tom and Stef will discuss this week. No, for real this time.
 
-  * `ember-handlebars-caps-lookup` [#3218](https://github.com/emberjs/ember.js/pull/3218)
+* `ember-handlebars-caps-lookup` [#3218](https://github.com/emberjs/ember.js/pull/3218)
 
      Needs follow up from [@xtian](https://github.com/xtian).
 
      Resolution: Ping @xtian
 
-  * `ember-testing-simple-setup` [#3785](https://github.com/emberjs/ember.js/pull/3785)
+* `ember-testing-simple-setup` [#3785](https://github.com/emberjs/ember.js/pull/3785)
 
     Tom and Stef still need to review.
 
     Resolution: Tom and Stef will review.
 
-  * `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
+* `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
 
     There are still some decisions around [lazy loading code](https://code.stypi.com/stefanpenner/lazy-loading)
     and query params.
 
     resolution: Alex and Stef will discuss lazy stuff.
 
-  * `composable-computed-properties` [#3696](https://github.com/emberjs/ember.js/pull/3696)
+* `composable-computed-properties` [#3696](https://github.com/emberjs/ember.js/pull/3696)
 
     resolution:  stefan will work with David monday or tuesday to get this in. A "Go" then.
 
 
-  * `ember-routing-inherits-parent-model` [#4246](https://github.com/emberjs/ember.js/pull/4246)
+* `ember-routing-inherits-parent-model` [#4246](https://github.com/emberjs/ember.js/pull/4246)
     
     resolution: "Go", already in beta
 
-  * `ember-handlebars-log-primitives` [#4252](https://github.com/emberjs/ember.js/pull/4252)
+* `ember-handlebars-log-primitives` [#4252](https://github.com/emberjs/ember.js/pull/4252)
     
     resolution: "Go"
 
-  * `ember-document-title` [#3689](https://github.com/emberjs/ember.js/pull/3689)
+* `ember-document-title` [#3689](https://github.com/emberjs/ember.js/pull/3689)
 
     Examples from @machty of current behavior:
 
-     * [Single static title](http://jsbin.com/ucanam/3299)
-     * [Basic example of titleToken + title](http://jsbin.com/ucanam/3302)
-     * [Basic example of titleToken + title (reversed)](http://jsbin.com/ucanam/3300)
-     * [titleToken bound to controller/model properties](http://jsbin.com/ucanam/3303)
-     * [Overriding doc.title format in deeper routes](http://jsbin.com/ucanam/3304)
+    * [Single static title](http://jsbin.com/ucanam/3299)
+    * [Basic example of titleToken + title](http://jsbin.com/ucanam/3302)
+    * [Basic example of titleToken + title (reversed)](http://jsbin.com/ucanam/3300)
+    * [titleToken bound to controller/model properties](http://jsbin.com/ucanam/3303)
+    * [Overriding doc.title format in deeper routes](http://jsbin.com/ucanam/3304)
     
     resolution: Still "No go", tokenization needs some polish related to nested resources
 
 #### Features currently slated for 1.5.0 beta series
 The core team reviewed the following pull requests for already enabled in canary builds for inclusion in the 1.5.x beta series. All still have a "Go" vote.
 
-  * `ember-testing-routing-helpers` [#3711](https://github.com/emberjs/ember.js/pull/3711)
-  * `ember-testing-triggerEvent-helper` [#3792](https://github.com/emberjs/ember.js/pull/3792)
-  * `computed-read-only` [#3879](https://github.com/emberjs/ember.js/pull/3879)
-  * `ember-metal-is-blank` [#4049](https://github.com/emberjs/ember.js/pull/4049)
-  * `ember-eager-url-update` [#4122](https://github.com/emberjs/ember.js/pull/4122)
-  * `ember-routing-auto-location` [#3725](https://github.com/emberjs/ember.js/pull/3725)
-  * `ember-routing-bound-action-name` [#3936](https://github.com/emberjs/ember.js/pull/3936)
+* `ember-testing-routing-helpers` [#3711](https://github.com/emberjs/ember.js/pull/3711)
+* `ember-testing-triggerEvent-helper` [#3792](https://github.com/emberjs/ember.js/pull/3792)
+* `computed-read-only` [#3879](https://github.com/emberjs/ember.js/pull/3879)
+* `ember-metal-is-blank` [#4049](https://github.com/emberjs/ember.js/pull/4049)
+* `ember-eager-url-update` [#4122](https://github.com/emberjs/ember.js/pull/4122)
+* `ember-routing-auto-location` [#3725](https://github.com/emberjs/ember.js/pull/3725)
+* `ember-routing-bound-action-name` [#3936](https://github.com/emberjs/ember.js/pull/3936)
 
 
 #### Feature Process
@@ -101,15 +101,15 @@ Process:
     * PR is merged so makes it into a canary build
 * Feature is added to [Features Pending 'Go' Decision](https://github.com/emberjs/ember.js/issues/4052) Issue
 * New Issue is created with a check-list of items to be completed prior to receiving a 'Go' vote. 
-  * This should include at least the following entries:
-    * Security Audit
-    * Core Team Sign-off
-  * Should be given a special tag (to make it easy to find later)
-  * Should be assigned to the original feature contributor
-  * This can serve as the proper place to ask for changes/fixes to the feature
-  * Once the feature has gotten a 'Go' decision
-    * The issue is closed.
-    * It is added to `features.json` with a value of `true`.
+    * This should include at least the following entries:
+        * Security Audit
+        * Core Team Sign-off
+    * Should be given a special tag (to make it easy to find later)
+    * Should be assigned to the original feature contributor
+    * This can serve as the proper place to ask for changes/fixes to the feature
+    * Once the feature has gotten a 'Go' decision
+        * The issue is closed.
+        * It is added to `features.json` with a value of `true`.
 
 resolution: "Go" and CONTRIBUTOR.md should be update accordingly.
 

--- a/content/core-team-meeting-minutes-2014-02-07.md
+++ b/content/core-team-meeting-minutes-2014-02-07.md
@@ -101,7 +101,7 @@ Process:
     * PR is merged so makes it into a canary build
 * Feature is added to [Features Pending 'Go' Decision](https://github.com/emberjs/ember.js/issues/4052) Issue
 * New Issue is created with a check-list of items to be completed prior to receiving a 'Go' vote. 
-  This should include at least the following entries:
+  * This should include at least the following entries:
     * Security Audit
     * Core Team Sign-off
   * Should be given a special tag (to make it easy to find later)

--- a/content/core-team-meeting-minutes-2014-02-14.md
+++ b/content/core-team-meeting-minutes-2014-02-14.md
@@ -48,13 +48,13 @@ related to pre-release versions of Ember have a high likelihood of no longer bei
 Stack Overflow has a policy of not deleting questions related to older versions of software,
 but we think pre-release software is exceptional for a few reasons:
     
-  * pre-release software is often undocumented and unfinished, leading people to use
+* pre-release software is often undocumented and unfinished, leading people to use
     Stack Overflow as a place to find answers at higher rates than for relased software
-  * people should not continue using pre-release software for long after an official
+* people should not continue using pre-release software for long after an official
     release, so there is little value in having those answers around for future reference
-  * good questions might have wildly different answers before and after a 1.0 release
+* good questions might have wildly different answers before and after a 1.0 release
     but there's no way for a new user to know
-  * some questions themselves will no longer make sense as features are added or removed
+* some questions themselves will no longer make sense as features are added or removed
 
 An example of a question that should be deleted is this [question related to Ember.Button](http://stackoverflow.com/questions/8672287/ember-js-how-to-use-em-button). Ember.Button has long been deprecated and removed. The pattern for actions has changed significantly since that question was asked in December 2011. However, someone wondering how to handle buttons in Ember who searches for "ember and buttons stackoverflow" will get this question as a top result.
 
@@ -66,25 +66,25 @@ Resolution: @trek will get this list created somehow.
 #### Features pending 'Go' decision.
 The core team reviewed the following pull requests for future inclusion in the 1.6.x beta series:
 
-  *  `ember-routing-named-substates` [#3655](https://github.com/emberjs/ember.js/pull/3655)
+*  `ember-routing-named-substates` [#3655](https://github.com/emberjs/ember.js/pull/3655)
     
       @stefanpenner and @tomdale still need to pow-wow on this.
 
       Resolution: @stefanpenner and @tomdale will speak.
 
-  *  `ember-testing-simple-setup` [#3785](https://github.com/emberjs/ember.js/pull/3785)
+*  `ember-testing-simple-setup` [#3785](https://github.com/emberjs/ember.js/pull/3785)
 
     @stefanpenner and @tomdale still need to pow-wow on this.
 
     Resolution: @stefanpenner and @tomdale will speak.
 
-  *  `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
+*  `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
     
     @wycats and @machty continued discussion on lazy loading. Goal is to get it in during this beta cycle
   
     Resolution: @machty & @stefanpenner have a man-date to discuss lazy loading.
 
-  *  `composable-computed-properties` [#3696](https://github.com/emberjs/ember.js/pull/3696)
+*  `composable-computed-properties` [#3696](https://github.com/emberjs/ember.js/pull/3696)
   
   Still blocked on [computed.literal](https://github.com/emberjs/ember.js/pull/4185)
 
@@ -92,21 +92,21 @@ The core team reviewed the following pull requests for future inclusion in the 1
   Resolution: The original behavior wasn't intended. Changing now might be breaking change
   in some people's apps. We'll put it through a multi-cycle deprecation/removal path.
 
-  *  `ember-metal-computed-empty-array` [#4219](https://github.com/emberjs/ember.js/pull/4219)
+*  `ember-metal-computed-empty-array` [#4219](https://github.com/emberjs/ember.js/pull/4219)
 
   Resolution: "Go". Upgrade to a Bugfix is it doesn't require a flag.
 
-  *  `ember-runtime-test-friendly-promises` [#4176](https://github.com/emberjs/ember.js/pull/4176)
+*  `ember-runtime-test-friendly-promises` [#4176](https://github.com/emberjs/ember.js/pull/4176)
 
   Resolution: Peter will try in [Skylight](https://www.skylight.io/)'s tests and
   offer feedback
 
-  *  `ember-routing-inherits-parent-model` [#4246](https://github.com/emberjs/ember.js/pull/4246)
+*  `ember-routing-inherits-parent-model` [#4246](https://github.com/emberjs/ember.js/pull/4246)
 
   Resolution: Already conceptually a "Go". @machty will make nestable routes in the next week or so so this can be merged.
 
 
-  * [BUGFIX beta Still update HTML5 history if the previous state was null](https://github.com/emberjs/ember.js/pull/4235)
+* [BUGFIX beta Still update HTML5 history if the previous state was null](https://github.com/emberjs/ember.js/pull/4235)
 
   iframes may set null values onto the HTML5 history state. The router will sometimes pick up the null value as current
   instead of the window's nominal state (which was set by Ember). The old logic required that a prior state be present, 

--- a/content/core-team-meeting-minutes-2014-03-07.md
+++ b/content/core-team-meeting-minutes-2014-03-07.md
@@ -26,12 +26,12 @@ core team member and let them know!
 
 #### Features pending 'Go' decision. [Tracking Issue](https://github.com/emberjs/ember.js/issues/4052)
 
-  *  `ember-routing-add-model-option` [#4293](https://github.com/emberjs/ember.js/pull/4293)
+*  `ember-routing-add-model-option` [#4293](https://github.com/emberjs/ember.js/pull/4293)
     Resolution: Go
 
 ### PR's/Issues To Review
 
-  * Query Params New - Sticky Params?
+* Query Params New - Sticky Params?
 
     Should query paramters remain on route change? When do we want it? All the time?
     How do we disable it? Proposals thus far:
@@ -59,12 +59,12 @@ core team member and let them know!
     ```
 
     some options:
-      * Preserve stickiness as the default, but add a (query-params-reset) subexpression helper
+    * Preserve stickiness as the default, but add a (query-params-reset) subexpression helper
         (in addition to query-params) that can take 0 or more args and will reset any query params
         not explicitly specified in the helper invocation. The puts the stickiness in the control
         of the caller (the link-to helper).
 
-      * Add a sticky option to the route query params config hash, which defaults to true. If set to
+    * Add a sticky option to the route query params config hash, which defaults to true. If set to
         false, any links into that route will reset (unless QP values are explicitly provided in the
         link-to helper), but any links to that route from within that route hierarchy will be sticky,
         which effectively makes it so that if you leave a route and come back into it via a link-to,
@@ -77,7 +77,7 @@ core team member and let them know!
       Resolution: Sticky by default, with appropriate escape valves to opt out per route change
 
 
-  * [ES6 ember-metal, ember-runtime, ember-debug](https://github.com/emberjs/ember.js/pull/4374)
+* [ES6 ember-metal, ember-runtime, ember-debug](https://github.com/emberjs/ember.js/pull/4374)
 
     Work is currently being done (by @thomasaboyt amongst others) on the es6-module-transpiler
     to remove the need for intermediate variables. This will both reduce filesize (less total
@@ -92,14 +92,14 @@ core team member and let them know!
 
     RESOLUTION: Merge (pending specific issues that have already been noted), but before shipping another globals build we should deal with the file size issue. We have ~7 weeks until the 1.6 release.
 
-  * [The `each` helper checks that the metamorph tags have the same parent.](https://github.com/emberjs/ember.js/pull/4404)
+* [The `each` helper checks that the metamorph tags have the same parent.](https://github.com/emberjs/ember.js/pull/4404)
 
     This was generally approved in the 2014-02-28 meeting once some verbiage tweaks were made. @trek's suggested
     changes have been made, this is ready to go.
 
     Resolution: merge.
 
-  * [FEATURE Ember.computed.instance](https://github.com/emberjs/ember.js/pull/4291)
+* [FEATURE Ember.computed.instance](https://github.com/emberjs/ember.js/pull/4291)
 
     > A computed property that creates a new instance of source. `source` can be any
     > Class constructor, object, array, or a path to a local property.  Optionally you can
@@ -108,7 +108,7 @@ core team member and let them know!
 
   Resolution: make it an add on that’s not core. CPM.
 
-  * [Deprecate edge-case get and normalizeTuple behavior before fixes](https://github.com/emberjs/ember.js/pull/4124)
+* [Deprecate edge-case get and normalizeTuple behavior before fixes](https://github.com/emberjs/ember.js/pull/4124)
 
     PR [#3852](https://github.com/emberjs/ember.js/pull/3852) changes some edge case behavior for get and normalizeTuple. Ahead of those changes, this commit introduces deprecation notices.
 
@@ -117,7 +117,7 @@ core team member and let them know!
     * Deprecate normalizeTuple calls that return a non-global contenxt
       and a simple global path.
 
-  * [Deprecate global access from templates](https://github.com/emberjs/ember.js/pull/4459)
+* [Deprecate global access from templates](https://github.com/emberjs/ember.js/pull/4459)
 
     PR by @mixonic:
 
@@ -130,7 +130,7 @@ core team member and let them know!
     >
     > @ebryn yo.
 
-  * [Container throws if injection registered for already instantiated type](https://github.com/emberjs/ember.js/pull/4328)
+* [Container throws if injection registered for already instantiated type](https://github.com/emberjs/ember.js/pull/4328)
 
     > Prior to this commit, the container would happily allow you to register an injection for a
     > type that had already been instantiated. This led to confusing-to-debug situations where an
@@ -143,7 +143,7 @@ core team member and let them know!
 
     Resolution: @stefanpenner & @wycats will chat.
 
-  * [Expose asObject to Ember.Handlebars.precompile](https://github.com/emberjs/ember.js/pull/4097)
+* [Expose asObject to Ember.Handlebars.precompile](https://github.com/emberjs/ember.js/pull/4097)
 
     Comment from @rwjblue:
 

--- a/content/core-team-meeting-minutes-2014-03-14.md
+++ b/content/core-team-meeting-minutes-2014-03-14.md
@@ -25,7 +25,7 @@ core team member and let them know!
 ### Topics
 
 ### Go/No-Go Feature Listing
-  *  `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
+*  `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
      Still a no-go, while @machty and @wycats hash out the specifics
 
 

--- a/content/core-team-meeting-minutes-2014-03-21.md
+++ b/content/core-team-meeting-minutes-2014-03-21.md
@@ -26,18 +26,18 @@ core team member and let them know!
 #### PRs/Issues To Review
 We reviewed the following PRs and Issues:
 
-  *  `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
+*  `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
 
     Nothing new here. We're working very hard to get this correct the first time
     and have something to demo at EmberConf.
 
-  * Move instanceMetas into object's meta [#4559](https://github.com/emberjs/ember.js/pull/4559)
+* Move instanceMetas into object's meta [#4559](https://github.com/emberjs/ember.js/pull/4559)
 
     InstanceMetas for objects' ReduceComputedPropertys are stored on the RCP instance (ie. on the descriptor) as `this._instanceMetas[key]` where key = guidOfTheObject + ':' + propertyName (see http://git.io/t9bKxA). The RCP can't know when the object is garbage collected, hence the _instanceMetas array grows unbounded.
 
     Resolution: if David Hamilton +1’s, we merge as a bugfix.
 
-  * Allow multiple arguments to be passed to EmberStringUtils.fmt() [#4518](https://github.com/emberjs/ember.js/pull/4518)
+* Allow multiple arguments to be passed to EmberStringUtils.fmt() [#4518](https://github.com/emberjs/ember.js/pull/4518)
 
     This allows you to use Ember.String.fmt with the same multi-arg signature as String#fmt:
 
@@ -49,7 +49,7 @@ We reviewed the following PRs and Issues:
 
     Resolution: Seems reasonable. Merge
 
-  * Deprecate App.Store in favor of App.ApplicationStore [#1808](https://github.com/emberjs/data/pull/1808)
+* Deprecate App.Store in favor of App.ApplicationStore [#1808](https://github.com/emberjs/data/pull/1808)
 
     This makes the application level store lookup much closer to the reset of our conventions (ala `App.ApplicationAdapter` and `App.ApplicationSerializer`).
 

--- a/content/core-team-meeting-minutes-2014-03-21.md
+++ b/content/core-team-meeting-minutes-2014-03-21.md
@@ -49,16 +49,16 @@ We reviewed the following PRs and Issues:
 
     Resolution: Seems reasonable. Merge
 
-* Deprecate App.Store in favor of App.ApplicationStore [#1808](https://github.com/emberjs/data/pull/1808)
+  * Deprecate App.Store in favor of App.ApplicationStore [#1808](https://github.com/emberjs/data/pull/1808)
 
-  This makes the application level store lookup much closer to the reset of our conventions (ala `App.ApplicationAdapter` and `App.ApplicationSerializer`).
+    This makes the application level store lookup much closer to the reset of our conventions (ala `App.ApplicationAdapter` and `App.ApplicationSerializer`).
 
-  This change also allows specifying a custom store when using non-global resolver (i.e. EAK/ember-cli). Previously, we were only looking for a property `Store` hung off of the application instance. Now you can have a module named (in the case of stock EAK setup):
-   `app/stores/application` or `app/application/store.js` (pods structure).
+    This change also allows specifying a custom store when using non-global resolver (i.e. EAK/ember-cli). Previously, we were only looking for a property `Store` hung off of the application instance. Now you can have a module named (in the case of stock EAK setup):
+     `app/stores/application` or `app/application/store.js` (pods structure).
 
-  A deprecation warning was added, and the prior technique still works so this is not a breaking change (although I believe that we should remove before the prior lookup prior to 1.0).
+    A deprecation warning was added, and the prior technique still works so this is not a breaking change (although I believe that we should remove before the prior lookup prior to 1.0).
 
-  Resolution: Seems reasonable. Merge
+    Resolution: Seems reasonable. Merge
 
 
 

--- a/content/core-team-meeting-minutes-2014-04-04.md
+++ b/content/core-team-meeting-minutes-2014-04-04.md
@@ -32,8 +32,8 @@ core team member and let them know!
 
   Still, checking `obj[keyName] === value` in these [lines] (https://github.com/selvagsz/ember.js/blob/master/packages_es6/ember-metal/lib/property_set.js#L52-54) is bypassed in two cases
 
-  * If the setter value is `undefined`
-  * If the setter property lies inside the proxied content
+    * If the setter value is `undefined`
+    * If the setter property lies inside the proxied content
 
   Using `get(obj, keyName)` might resolve. But was quite nervous to do that as it may involve some additional function calls
 

--- a/content/core-team-meeting-minutes-2014-06-20.md
+++ b/content/core-team-meeting-minutes-2014-06-20.md
@@ -43,7 +43,7 @@ core team member and let them know!
 
 ### Features pending 'Go' decisions
 
-  * [ember-routing-consistent-resources](https://github.com/emberjs/ember.js/pull/4251)
+* [ember-routing-consistent-resources](https://github.com/emberjs/ember.js/pull/4251)
 
     This PR adds .index, .loading, and .error sub-routes for resources created even
     if no callback was provided so `this.resource('foo')` and

--- a/content/core-team-meeting-minutes-2014-07-11.md
+++ b/content/core-team-meeting-minutes-2014-07-11.md
@@ -60,36 +60,36 @@ underlying library that will power Ember.js's rewritten view layer.
 
 ### Features Pending Go/No-Go
 
-   * [ember-metal-is-present](https://github.com/emberjs/ember.js/pull/5136)
+* [ember-metal-is-present](https://github.com/emberjs/ember.js/pull/5136)
 
       Resolution: this is excellent addon material. Revert.
 
-   * [event-dispatcher-can-disable-event-manager](https://github.com/emberjs/ember.js/pull/5116)
+* [event-dispatcher-can-disable-event-manager](https://github.com/emberjs/ember.js/pull/5116)
 
       Resolution: event dispatcher is being deprecated, but we'll have hooks for
                   libraries like (Hammer.js)[http://hammerjs.github.io/] to
                   integrate with. Revert.
 
-   * [ember-routing-linkto-target-attribute]
+* [ember-routing-linkto-target-attribute]
 
       Resolution: This is a Go.
 
 ### Issues for Discussion
 
-  * [Fix {{#with view.foo as bar}} #5115](https://github.com/emberjs/ember.js/pull/5115)
+* [Fix {{#with view.foo as bar}} #5115](https://github.com/emberjs/ember.js/pull/5115)
 
     This is a bug. Merged.
 
-  * [Fix usage of document.body.contains](https://github.com/emberjs/ember.js/pull/5089)
+* [Fix usage of document.body.contains](https://github.com/emberjs/ember.js/pull/5089)
 
     This is not required in metal-views, so the problem should go away. The suggested
     polyfill with feature flag for 1.7 OK until that time.
 
-  * [Force remove `required` attribute for IE8](https://github.com/emberjs/ember.js/pull/4936)
+* [Force remove `required` attribute for IE8](https://github.com/emberjs/ember.js/pull/4936)
 
     Scumbag IE. This is merged
 
-  * [Actions should be looked up via `Ember.get`](https://github.com/emberjs/ember.js/pull/4920)
+* [Actions should be looked up via `Ember.get`](https://github.com/emberjs/ember.js/pull/4920)
 
     `:-1:` as is, need to re-work and add a 're-bubble' phase that checks `actionMissing`
     good idea, but seems like it may require a lot of work.

--- a/content/core-team-meeting-minutes-2014-08-14.md
+++ b/content/core-team-meeting-minutes-2014-08-14.md
@@ -55,7 +55,7 @@ Currently the Guides and API are not versioned, which increasingly leads to
 pain around new feature documentation. The plan is to beging publishing guides
 and API to a subdomains and version them:
 
-  * http://guides.emberjs.com/ (defaults to latest)
-  * http://guides.emberjs.com/1.8
-  * http://api.ember.js.com/ (defaults to latest)
-  * http://api.ember.js.com/1.8
+* http://guides.emberjs.com/ (defaults to latest)
+* http://guides.emberjs.com/1.8
+* http://api.ember.js.com/ (defaults to latest)
+* http://api.ember.js.com/1.8

--- a/content/countdown-to-the-new-year-ember-mapbox-gl.md
+++ b/content/countdown-to-the-new-year-ember-mapbox-gl.md
@@ -31,9 +31,9 @@ Yes, it's satisfying to solve the problem yourself, but it's smarter—and quick
 say, [building your own file uploader](https://emberobserver.com/?query=file%20upload).
 
 A cursory glance at the available mapping addons show up a few options:
-  - [ember-mapbox-gl](https://github.com/kturney/ember-mapbox-gl) (Full disclosure: I'm a contributor, although [kturney](https://github.com/kturney) does most of the work!)
-  - [ember-leaflet](https://github.com/miguelcobain/ember-leaflet)
-  - [ember-google-maps](https://github.com/sandydoo/ember-google-maps)
+- [ember-mapbox-gl](https://github.com/kturney/ember-mapbox-gl) (Full disclosure: I'm a contributor, although [kturney](https://github.com/kturney) does most of the work!)
+- [ember-leaflet](https://github.com/miguelcobain/ember-leaflet)
+- [ember-google-maps](https://github.com/sandydoo/ember-google-maps)
  
 Am I missing any? Let me know. But I'm pretty confident these are the top mapping addons.
 

--- a/content/december-event.md
+++ b/content/december-event.md
@@ -21,8 +21,8 @@ To qualify for any of our random assortment of thank you goodies (that we’ve d
 ## Participation Activities
 
 - Submitting PRs for issues
-  - In the [Ember Learn org](https://github.com/ember-learn)
-  - That have the `DecEmber` label
+    - In the [Ember Learn org](https://github.com/ember-learn)
+    - That have the `DecEmber` label
 - Writing Issues for repositories in the ember-learn org. We will mark them with the `DecEmber` label if they qualify.
 - Creating Illustrations: Maybe you have an artistic side, and illustrating code concepts is fun for you! If that’s the case, there are always illustrations that would enhance the guides, and those are very welcome for this event!
 - If you have another idea that you think would help support the Learning Core Team, let us know!

--- a/content/ember-1-13-0-released.md
+++ b/content/ember-1-13-0-released.md
@@ -298,11 +298,11 @@ for implementing this feature.
 In preparation for Ember 2.0, 1.13 introduces many deprecations. These include:
 
 - All view APIs in Ember. [See deprecation guide](http://emberjs.com/deprecations/v1.x/#toc_ember-view)
-  - `Ember.CoreView`, `Ember.View`, `Ember.CollectionView`, `Ember.ContainerView`
-  - `{{view 'some-helper'}}`
-  - The `{{view}}` keyword for accessing properties on a view
-  - `Ember.Select` and `{{view "select"}}`. [See deprecation guide](http://emberjs.com/deprecations/v1.x/#toc_ember-select)
-  - `Ember.LinkView` in favor of `Ember.LinkComponent`. [See deprecation guide](http://emberjs.com/deprecations/v1.x/#toc_ember-linkview)
+    - `Ember.CoreView`, `Ember.View`, `Ember.CollectionView`, `Ember.ContainerView`
+    - `{{view 'some-helper'}}`
+    - The `{{view}}` keyword for accessing properties on a view
+    - `Ember.Select` and `{{view "select"}}`. [See deprecation guide](http://emberjs.com/deprecations/v1.x/#toc_ember-select)
+    - `Ember.LinkView` in favor of `Ember.LinkComponent`. [See deprecation guide](http://emberjs.com/deprecations/v1.x/#toc_ember-linkview)
 - Options to the `{{#each` helper that trigger a legacy and poorly performing
   legacy layer. These options are: `itemView`, `itemViewClass`, `tagName`, `emptyView` and `emptyViewClass`.
 - The `itemController` argument for `{{#each`.

--- a/content/ember-3-1-released.md
+++ b/content/ember-3-1-released.md
@@ -322,12 +322,12 @@ Ember Data 3.1 contains bug fixes and build improvements for Ember Data.
     - `Ember.Map` adds a static `create` method (which simply instantiates itself with `new Ember.Map()`)
     - `Ember.Map` does not accept constructor arguments
     - `Ember.Map` does not have:
-      - `@@species`
-      - `@@iterator`
-      - `entries`
-      - `values` This implementation adds a deprecated backwards compatibility for:
-          - `copy`
-          - `isEmpty`
+        - `@@species`
+        - `@@iterator`
+        - `entries`
+        - `values` This implementation adds a deprecated backwards compatibility for:
+            - `copy`
+            - `isEmpty`
 
 This is needed because `Map` requires instantiation with `new`, and by default Babel transpilation will do `superConstructor.apply(this, arguments)` which throws an error with native `Map`. The desired code (if we lived in an "only native class" world) would be:
 

--- a/content/ember-3-11-released.md
+++ b/content/ember-3-11-released.md
@@ -127,19 +127,19 @@ Finally, it should be noted that the `{{action}}` modifier, and in some cases, D
 
 Inject Parameter Normalization normalizes this contract for all Ember base classes - that is, framework classes that are provided by Ember:
 
-  - `GlimmerComponent`
-  - `EmberComponent`
-  - `Service`
-  - `Route`
-  - `Controller`
-  - `Helper`
+- `GlimmerComponent`
+- `EmberComponent`
+- `Service`
+- `Route`
+- `Controller`
+- `Helper`
 
 Along with framework clases provided by Ember Data:
 
-  - `Model`
-  - `Adapter`
-  - `Serializer`
-  - `Transform`
+- `Model`
+- `Adapter`
+- `Serializer`
+- `Transform`
 
 For more info please refer to [the RFC](https://github.com/emberjs/rfcs/blob/master/text/0451-injection-parameter-normalization.md).
 

--- a/content/ember-data-1-13-released.md
+++ b/content/ember-data-1-13-released.md
@@ -577,7 +577,7 @@ error handling:
 - Cleaner adapter hooks for errors
 - Using JSON API Error object format
 
-###Cleaner adapter hooks for errors
+### Cleaner adapter hooks for errors
 
 Previously, if you were subclassing the `RestAdapter` you could overwrite
 `ajaxSuccess` and `ajaxError` hooks to implement custom error handling.
@@ -619,7 +619,7 @@ underlying implementation and will allow us to easily use methods like
 [fetch](https://developers.google.com/web/updates/2015/03/introduction-to-fetch?hl=en)
 in the future.
 
-###Using JSON API Error object format
+### Using JSON API Error object format
 Similarly to the rest of Ember Data 1.13, we have refactored the error handling to use JSON API. JSON API has specified an
 [error objects](http://jsonapi.org/format/#error-objects)
 format. Starting with Ember Data 1.13 we are using JSON API format to

--- a/content/ember-data-1-13-released.md
+++ b/content/ember-data-1-13-released.md
@@ -297,8 +297,8 @@ if the network is down, you can implement `shouldBackgroundReloadRecord`
 ```js
 shouldBackgroundReloadRecord: function(store, snapshot) {
   if (window.navigator.connection === 'cellular' ||
-  	window.navigator.connection === 'none') {
-  	return false;
+    window.navigator.connection === 'none') {
+    return false;
   } else {
     return true;
   }
@@ -422,8 +422,7 @@ and your server payload looked like:
 
 Your serializer would get the payload passed in an `extract` hook and its job was to:
  
-- normalize and `store.push` everything that is not the `primary record`, in this
-	case the array of sideloaded accounts
+- normalize and `store.push` everything that is not the `primary record`, in this case the array of sideloaded accounts
 - normalize and return the primary data, in this case the `user` data
 
 Having these two ways of pushing data to the store, with both returning primary record data

--- a/content/ember-data-2-3-released.md
+++ b/content/ember-data-2-3-released.md
@@ -194,10 +194,10 @@ in [RFC 57](https://github.com/emberjs/rfcs/pull/57). References is a
 low level API to perform meta-operations on records, has-many
 relationships and belongs-to relationships:
 
-  * get the current local data synchronously without triggering a fetch or producing a promise
-  * notify the store that a fetch for a given record has begun, and provide a promise for its result
-  * similarly, notify a record that a fetch for a given relationship has begun, and provide a promise for its result
-  * retrieve server-provided metadata about a record or relationship
+* get the current local data synchronously without triggering a fetch or producing a promise
+* notify the store that a fetch for a given record has begun, and provide a promise for its result
+* similarly, notify a record that a fetch for a given relationship has begun, and provide a promise for its result
+* retrieve server-provided metadata about a record or relationship
 
 Consider the following `post` model:
 

--- a/content/ember-data-2-4-released.md
+++ b/content/ember-data-2-4-released.md
@@ -80,10 +80,10 @@ in [RFC 57](https://github.com/emberjs/rfcs/pull/57). References is a
 low level API to perform meta-operations on records, has-many
 relationships and belongs-to relationships:
 
-  * get the current local data synchronously without triggering a fetch or producing a promise
-  * notify the store that a fetch for a given record has begun, and provide a promise for its result
-  * similarly, notify a record that a fetch for a given relationship has begun, and provide a promise for its result
-  * retrieve server-provided metadata about a record or relationship
+* get the current local data synchronously without triggering a fetch or producing a promise
+* notify the store that a fetch for a given record has begun, and provide a promise for its result
+* similarly, notify a record that a fetch for a given relationship has begun, and provide a promise for its result
+* retrieve server-provided metadata about a record or relationship
 
 Consider the following `post` model:
 

--- a/content/ember-data-2-5-released.md
+++ b/content/ember-data-2-5-released.md
@@ -48,10 +48,10 @@ in [RFC 57](https://github.com/emberjs/rfcs/pull/57). References is a
 low level API to perform meta-operations on records, has-many
 relationships and belongs-to relationships:
 
-  - get the current local data synchronously without triggering a fetch or producing a promise
-  - notify the store that a fetch for a given record has begun, and provide a promise for its result
-  - similarly, notify a record that a fetch for a given relationship has begun, and provide a promise for its result
-  - retrieve server-provided metadata about a record or relationship
+- get the current local data synchronously without triggering a fetch or producing a promise
+- notify the store that a fetch for a given record has begun, and provide a promise for its result
+- similarly, notify a record that a fetch for a given relationship has begun, and provide a promise for its result
+- retrieve server-provided metadata about a record or relationship
 
 Consider the following `post` model:
 

--- a/content/emberjs-native-class-update-2019-edition.md
+++ b/content/emberjs-native-class-update-2019-edition.md
@@ -458,15 +458,15 @@ let person = new Person('Carol', 'Danvers');
 This means that any utility classes written using `EmberObject` can be rewritten and converted away from it. In fact, you should only need to remember the rules in this post for _framework primitives_, such as:
 
 * Ember
-  * `@ember/component`
-  * `@ember/controller`
-  * `@ember/helper`
-  * `@ember/route`
-  * `@ember/service`
+    * `@ember/component`
+    * `@ember/controller`
+    * `@ember/helper`
+    * `@ember/route`
+    * `@ember/service`
 * Ember Data
-  * `@ember-data/adapter`
-  * `@ember-data/model`
-  * `@ember-data/serializer`
+    * `@ember-data/adapter`
+    * `@ember-data/model`
+    * `@ember-data/serializer`
 
 `@glimmer/component`, which was just accepted via RFC, will be implemented _without_ extending `EmberObject` which means you will not need to remember the rules and exceptions for newer components either. In general, when in doubt, use native classes!
 

--- a/content/the-ember-times-issue-130.md
+++ b/content/the-ember-times-issue-130.md
@@ -94,11 +94,11 @@ and how these tie in with what you already learned about JavaScript in general! 
 to learn about the principles of Ember's first edition in more detail.
 
 - Octane Core Concepts Blog Series by [Chris Garrett (@pzuraq)](https://github.com/pzuraq)
-  - [Part 1: Native Classes](https://blog.emberjs.com/2019/02/11/coming-soon-in-ember-octane-part-1.html)
-  - [Part 2: Angle Brackets & Named Arguments](https://blog.emberjs.com/2019/02/19/coming-soon-in-ember-octane-part-2.html)
-  - [Part 3: Tracked Properties](https://blog.emberjs.com/2019/02/26/coming-soon-in-ember-octane-part-3.html)
-  - [Part 4: Modifiers](https://blog.emberjs.com/2019/03/06/coming-soon-in-ember-octane-part-4.html)
-  - [Part 5: Glimmer Components](https://blog.emberjs.com/2019/03/14/coming-soon-in-ember-octane-part-5.html)
+    - [Part 1: Native Classes](https://blog.emberjs.com/2019/02/11/coming-soon-in-ember-octane-part-1.html)
+    - [Part 2: Angle Brackets & Named Arguments](https://blog.emberjs.com/2019/02/19/coming-soon-in-ember-octane-part-2.html)
+    - [Part 3: Tracked Properties](https://blog.emberjs.com/2019/02/26/coming-soon-in-ember-octane-part-3.html)
+    - [Part 4: Modifiers](https://blog.emberjs.com/2019/03/06/coming-soon-in-ember-octane-part-4.html)
+    - [Part 5: Glimmer Components](https://blog.emberjs.com/2019/03/14/coming-soon-in-ember-octane-part-5.html)
 - [Most Common Mistakes Using Octane and How to Avoid Them](https://medium.com/ember-ish/the-most-common-ember-js-octane-mistakes-and-how-to-avoid-them-c6420e1b0423) by [Jen Weber (@jenweber)](https://github.com/jenweber)
 - [Bringing Clarity to Templates through Ember Octane](https://simplabs.com/blog/2019/12/20/clarity-in-templates/) by [Ricardo Mendes (@locks)](https://github.com/locks)
 - [Ember Octane Fundamentals Course on Frontend Masters (paid subscription)](https://frontendmasters.com/courses/ember-octane/) by [Mike North (@mike-north)](https://github.com/mike-north)

--- a/content/the-ember-times-issue-140.md
+++ b/content/the-ember-times-issue-140.md
@@ -34,13 +34,13 @@ On March 16—just in time for EmberConf!—[Ember 3.17 was officially announced
 Ember 3.17 introduced these changes:
 
 - Ember.js
-  - Significantly updated the Glimmer rendering engine
+    - Significantly updated the Glimmer rendering engine
 - Ember CLI
-  - Removed internal usage of `RSVP` in favor of native promises
-  - Removed `ember-cli-eslint` and `ember-cli-template-lint` in favor of `eslint` and `ember-template-lint`
-  - Ensured that `npm test` or `yarn test` fails when `lint:js` or `lint:hbs` fails
-  - Ensured that `npm test` or `yarn test` in an addon fails if `ember-try` scenarios fail
-  - Removed a number of older experiments (module unification and delayed transpilation)
+    - Removed internal usage of `RSVP` in favor of native promises
+    - Removed `ember-cli-eslint` and `ember-cli-template-lint` in favor of `eslint` and `ember-template-lint`
+    - Ensured that `npm test` or `yarn test` fails when `lint:js` or `lint:hbs` fails
+    - Ensured that `npm test` or `yarn test` in an addon fails if `ember-try` scenarios fail
+    - Removed a number of older experiments (module unification and delayed transpilation)
 
 To learn more about upgrading to Ember 3.17, please visit the [Ember Blog](https://blog.emberjs.com/2020/03/16/ember-3-17-released.html). We encourage you to help test 3.17 and 3.18 beta and report any bugs. Thank you!
 

--- a/content/the-ember-times-issue-148.md
+++ b/content/the-ember-times-issue-148.md
@@ -78,12 +78,12 @@ Check out the updates at [ember-twiddle.com](https://t.co/PMkoyGsnSv?amp=1) and 
 [Abhilash LR (@abhilashlr)](https://github.com/abhilashlr) blogs about **optimizing build timelines & bundle size** in your Ember apps, the first in a series on getting started with performance optimizations! Check out his tips and tricks in the writeup [here](https://abhilashlr.in/ember-performance-tweaks-part-1). Highlights include:
 
 * Speeding up development
-  * Removing tests from the dev build
-  * Removing Mirage from the dev build
-  * Minification, gzip or brotli compression, and fingerprinting
+    * Removing tests from the dev build
+    * Removing Mirage from the dev build
+    * Minification, gzip or brotli compression, and fingerprinting
 * Asset size
-  * Analyze bundle size and optimize asset size
-  * Removing dependencies not needed on app boot
+    * Analyze bundle size and optimize asset size
+    * Removing dependencies not needed on app boot
 
 > The smaller the page assets, the faster it is for the user to view them. The faster it is for the user to view the page with text and UI, the greater trust they have on our apps/websites.
 

--- a/content/the-emberjs-times-issue-75.md
+++ b/content/the-emberjs-times-issue-75.md
@@ -36,8 +36,8 @@ To qualify for any of our random assortment of thank you goodies (that we’ve d
 **Participation Activities**
 
 - Submitting PRs for issues
-  - In the [Ember Learn org](https://github.com/ember-learn)
-  - That have the `DecEmber` label
+    - In the [Ember Learn org](https://github.com/ember-learn)
+    - That have the `DecEmber` label
 - Writing Issues for repositories in the ember-learn org. We will mark them with the `DecEmber` label if they qualify.
 - Creating Illustrations: Maybe you have an artistic side, and illustrating code concepts is fun for you! If that’s the case, there are always illustrations that would enhance the guides, and those are very welcome for this event!
 - If you have another idea that you think would help support the Learning Core Team, let us know!


### PR DESCRIPTION
## Description

Related issue: https://github.com/ember-learn/ember-blog/issues/851

I enabled 5 rules in `markdownlint`:

- MD005
- MD007 (autofixed)
- MD010
- MD011
- MD018