### PR TITLE
Fixed lint errors from markdownlint (Part 3)

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -8,7 +8,6 @@
   "no-trailing-spaces": false,
   "no-multiple-blanks": false,
   "MD007": { "indent": 4 },
-  "MD031": false,
   "MD032": false,
   "MD034": false,
   "MD038": false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -8,7 +8,6 @@
   "no-trailing-spaces": false,
   "no-multiple-blanks": false,
   "MD007": { "indent": 4 },
-  "MD030": false,
   "MD031": false,
   "MD032": false,
   "MD034": false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -8,7 +8,6 @@
   "no-trailing-spaces": false,
   "no-multiple-blanks": false,
   "MD007": { "indent": 4 },
-  "MD028": false,
   "MD030": false,
   "MD031": false,
   "MD032": false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -8,7 +8,6 @@
   "no-trailing-spaces": false,
   "no-multiple-blanks": false,
   "MD007": { "indent": 4 },
-  "MD025": false,
   "MD028": false,
   "MD030": false,
   "MD031": false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -8,7 +8,6 @@
   "no-trailing-spaces": false,
   "no-multiple-blanks": false,
   "MD007": { "indent": 4 },
-  "MD022": false,
   "MD025": false,
   "MD028": false,
   "MD030": false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -8,7 +8,6 @@
   "no-trailing-spaces": false,
   "no-multiple-blanks": false,
   "MD007": { "indent": 4 },
-  "MD034": false,
   "MD038": false,
   "MD039": false,
   "MD040": false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -8,7 +8,6 @@
   "no-trailing-spaces": false,
   "no-multiple-blanks": false,
   "MD007": { "indent": 4 },
-  "MD038": false,
   "MD039": false,
   "MD040": false,
   "MD042": false,

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -8,7 +8,6 @@
   "no-trailing-spaces": false,
   "no-multiple-blanks": false,
   "MD007": { "indent": 4 },
-  "MD032": false,
   "MD034": false,
   "MD038": false,
   "MD039": false,

--- a/content/core-team-meeting-minutes-2013-12-06.md
+++ b/content/core-team-meeting-minutes-2013-12-06.md
@@ -23,11 +23,13 @@ If you have a topic you'd like to see covered, contact your favorite
 core team member and let them know!
 
 #### Attendees
+
 @ebryn, @krisselden, @machty, @stefanpenner, @tomdale, @trek, @wagenet, @wycats
 
 ### Topics
 
 #### Transparency
+
 We've heard a few comments that people would like greater Core Team transparency.
 Since the weekly meetings are the only significant group communication that isn't
 public, we'll be posting notes from these meetings.
@@ -39,6 +41,7 @@ Resolutions:
     to contact individual core team members if they have issued they’d like raised.
 
 #### HTMLBars
+
 @wycats says it’s ready to hand off to someone else. 
 
 Resolutions:

--- a/content/core-team-meeting-minutes-2013-12-20.md
+++ b/content/core-team-meeting-minutes-2013-12-20.md
@@ -20,14 +20,18 @@ If you have a topic you'd like to see covered, contact your favorite
 core team member and let them know!
 
 #### Attendees
+
 @krisselden, @machty, @stefanpenner, @tomdale, @trek, @wagenet, @wycats
 
 ### Topics
+
 #### Build Tools
+
 @wycats has been communicating with @jo_liss about using 
 [broccoli](https://github.com/joliss/broccoli/) as the basis for a build tools package.
 
 #### Ember Data
+
 Ember data is now less of an ORM and more of a pluggable framework for assembling
 your own data communication layer for Ember.js applications (with some nice defaults for
 people's whose APIs follow common patterns). However, the interface – especially on the 
@@ -40,6 +44,7 @@ Resolutions:
 * @tomdale, @wycats will publish an ember data update blog post.
 
 #### Query Params
+
 Some debate about the correct location for defining and handling query parameters
 (controller vs route).
 
@@ -48,6 +53,7 @@ Resolutions:
 * a smaller group will handle that discussion
 
 #### Pods
+
 During the face-to-face we floated the idea of organizing an application's files in a
 ["pod" structure](/blog/2013/12/17/whats-coming-in-ember-in-2014.html#toc_pod-directory-structure). 
 Feedback has been positive, but we want to get more real world stories about the pros and cons of

--- a/content/core-team-meeting-minutes-2014-01-03.md
+++ b/content/core-team-meeting-minutes-2014-01-03.md
@@ -38,6 +38,7 @@ gives a "go" or "no-go" vote to feature-flagged beta functionality.
 * make sure to add parentController immediately after merge (@kselden)
 * address https://github.com/emberjs/ember.js/issues/4050 (@stefanpenner)
 * ensure lookupFactory and creates with content
+
     ```
     {{#with foo controller=’someController}}
     ```

--- a/content/core-team-meeting-minutes-2014-01-03.md
+++ b/content/core-team-meeting-minutes-2014-01-03.md
@@ -36,7 +36,7 @@ gives a "go" or "no-go" vote to feature-flagged beta functionality.
 #### with-controller: go
 
 * make sure to add parentController immediately after merge (@kselden)
-* address https://github.com/emberjs/ember.js/issues/4050 (@stefanpenner)
+* address [https://github.com/emberjs/ember.js/issues/4050](https://github.com/emberjs/ember.js/issues/4050) (@stefanpenner)
 * ensure lookupFactory and creates with content
 
     ```

--- a/content/core-team-meeting-minutes-2014-01-03.md
+++ b/content/core-team-meeting-minutes-2014-01-03.md
@@ -19,9 +19,11 @@ If you have a topic you'd like to see covered, contact your favorite
 core team member and let them know!
 
 #### Attendees
+
 @ebryn, @krisselden, @machty, @stefanpenner, @trek, @wagenet, @wycats
 
 ### Go/No-Go for 1.4
+
 It's that time in the [beta release cycle](/builds/#/beta) where the core team
 gives a "go" or "no-go" vote to feature-flagged beta functionality.
 

--- a/content/core-team-meeting-minutes-2014-01-17.md
+++ b/content/core-team-meeting-minutes-2014-01-17.md
@@ -20,9 +20,11 @@ If you have a topic you'd like to see covered, contact your favorite
 core team member and let them know!
 
 #### Attendees
+
 @ebryn, @krisselden, @machty, @stefanpenner, @tomdale, @trek, @wagenet, @wycats, @wifelette
 
 ### Pending Go/No-Go
+
 We received feedback that too many flagged features in canary were
 not getting enough discussion from the core team early in the release cycle.
 
@@ -44,6 +46,7 @@ vote:
 * [ember-eager-url-update](https://github.com/emberjs/ember.js/pull/4122)
 
 #### [string-humanize](https://github.com/emberjs/ember.js/pull/3224) and [string-parameterize](https://github.com/emberjs/ember.js/pull/3953)
+
 There is a concern that this increases the surface area of API and the size of the framework
 without providing enough benefit that is unique to Ember.js. If the package manager ecosystem
 for browser JavaScript were more mature, these would clear cases for community contribution.
@@ -57,6 +60,7 @@ Resolutions:
 
 
 #### [ember-handlebars-caps-lookup](https://github.com/emberjs/ember.js/pull/3218)
+
 A bare capitalized word in Handlebars should look up on current scope.
 `{{CONSTANT}}` and `{{#each CONSTANT}}` did global lookup mostly by side effect, 
 this was not intended API, but we need to think through backwards compatibility
@@ -85,6 +89,7 @@ Resolutions:
 * @ebryn will provide feedback on the PR
 
 #### [composable-computed-properties](https://github.com/emberjs/ember.js/pull/3696)
+
 Possibly still needs some work (there some unhandled todos)? Will be a "go" when
 these are addressed.
 
@@ -93,6 +98,7 @@ Resolutions:
 * @trek will ask about the status of remaining todos
 
 #### [query-params-new](https://github.com/emberjs/ember.js/pull/4008)
+
 @wycats and @machty chatted about some last minute issues. This PR should be good soon.
 The removal of query prefixing should provide a nicer query string  (the `[]` prefixing only
 happens if two controllers in same hierarchy have the same parameter name).
@@ -103,6 +109,7 @@ Resolutions:
 
 
 #### [ember-routing-loading-error-substates](https://github.com/emberjs/ember.js/pull/3655)
+
 Currently `state/loading` and `state_loading` both reify into StateLoading under the current
 resolver. Custom resolvers (like those in EmberAppKit) don't have this issue, but the global
 resolver does. We can't make this work until modularization is done.

--- a/content/core-team-meeting-minutes-2014-01-27.md
+++ b/content/core-team-meeting-minutes-2014-01-27.md
@@ -23,11 +23,13 @@ This week's core team meeting was rescheduled from Friday, January 24 to Monday,
 due to the Google outage that affected Google Hangouts.
 
 #### Attendees
+
 @ebryn, @krisselden, @machty, @stefanpenner, @tomdale, @trek, @wagenet, @wycats
 
 ### Topics
 
 #### Issues Discussion:
+
 The core team discussed the following Github Issues
 
 * `ember-routing-auto-location` [#3725](https://github.com/emberjs/ember.js/pull/3725).

--- a/content/core-team-meeting-minutes-2014-01-31.md
+++ b/content/core-team-meeting-minutes-2014-01-31.md
@@ -52,7 +52,7 @@ core team member and let them know!
     this a "No go"
 
 
-*  `composable-computed-properties` [#3696](https://github.com/emberjs/ember.js/pull/3696)
+* `composable-computed-properties` [#3696](https://github.com/emberjs/ember.js/pull/3696)
 
     @wycats: aliased to short words in the examples, should be documented to match this?
     @ebryn:: new CP work may have issues, @wycats and @ebryn and David should talk.

--- a/content/core-team-meeting-minutes-2014-01-31.md
+++ b/content/core-team-meeting-minutes-2014-01-31.md
@@ -20,6 +20,7 @@ If you have a topic you'd like to see covered, contact your favorite
 core team member and let them know!
 
 #### Attendees
+
 @ebryn, @krisselden, @machty, @stefanpenner, @tomdale, @wifelette, @wycats
 
 ### Go/No-Go Feature Listing

--- a/content/core-team-meeting-minutes-2014-02-07.md
+++ b/content/core-team-meeting-minutes-2014-02-07.md
@@ -20,11 +20,13 @@ If you have a topic you'd like to see covered, contact your favorite
 core team member and let them know!
 
 #### Attendees
+
 @ebryn, @krisselden, @machty, @stefanpenner, @tomdale, @trek, @wagenet, @wycats
 
 ### Topics
 
 #### Features pending 'Go' decision.
+
 The core team reviewed the following pull requests for inclusion in the 1.5.x beta series:
 
 * `ember-routing-named-substates` [#3655](https://github.com/emberjs/ember.js/pull/3655)
@@ -78,6 +80,7 @@ The core team reviewed the following pull requests for inclusion in the 1.5.x be
     resolution: Still "No go", tokenization needs some polish related to nested resources
 
 #### Features currently slated for 1.5.0 beta series
+
 The core team reviewed the following pull requests for already enabled in canary builds for inclusion in the 1.5.x beta series. All still have a "Go" vote.
 
 * `ember-testing-routing-helpers` [#3711](https://github.com/emberjs/ember.js/pull/3711)
@@ -90,6 +93,7 @@ The core team reviewed the following pull requests for already enabled in canary
 
 
 #### Feature Process
+
 We reviewed the a proposed change to the process for adding features. This isn't a major departure, just an iteration
 on what we are currently doing:
 
@@ -114,5 +118,6 @@ Process:
 resolution: "Go" and CONTRIBUTOR.md should be update accordingly.
 
 #### Security Process
+
 Currently we do security releases all the way back to 1.0.x. At some point that will be untenable (not yet though).
 There was some discussions about Long Term Support release structures: every odd/even becomes LTS, or even 5th release, or we only support previous three revisions (which would be all releases in the last 4.5 months with our current release model).

--- a/content/core-team-meeting-minutes-2014-02-14.md
+++ b/content/core-team-meeting-minutes-2014-02-14.md
@@ -20,11 +20,14 @@ If you have a topic you'd like to see covered, contact your favorite
 core team member and let them know!
 
 #### Attendees
+
 @ebryn, @krisselden, @machty, @stefanpenner, @tomdale, @trek, @wagenet, @wycats
 
 
 ### Topics
+
 #### ES6ifying core
+
 Last month we completed the migration of [ember-data](https://github.com/emberjs) to the ES6 module syntax. This lets us use [clearer dependency declarations](https://github.com/emberjs/data/blob/master/packages/ember-data/lib/serializers/rest_serializer.js#L5-L8), stay clear of module syntax battles (you can export to whichever module format best conforms to your deeply held beliefs on JavaScript modules), and continues our pattern of bringing future JavaScript features to you today.
 
 Work has started on the [porting Ember.js to ES6 module syntax as well!](https://github.com/emberjs/ember.js/commit/8c0a52cb10efbaede8e14cca24fa5c05bcf121ff).
@@ -35,6 +38,7 @@ Resolution: @rwjblue hands off the grunt work to @trek and @fivetanley so he's n
 
 
 #### Ghost.js Admin
+
 The fine folks at [Ghost](https://ghost.org/) have hit a complexity ceiling with their current admin interface (a mixed client/server rendering solution with Backbone tossed in). They're [discussing various solutions for a rewrite](https://github.com/TryGhost/Ghost/issues/2144) and Ember.js is among the options.
 
 The core team discussed devoting some time to helping the Ghost team evaluate Ember.js as a possible solution.
@@ -43,6 +47,7 @@ If you'd like to help or weigh in – especially if you're a current Ghost user 
 Resolution: @trek will devote some time to helping the Ghost team. Possibly on a small spike.
 
 #### Getting rid of old Stack Overflow questions/answers
+
 We frequently get comments about older Stack Overflow questions and answers. Answers
 related to pre-release versions of Ember have a high likelihood of no longer being valid.
 Stack Overflow has a policy of not deleting questions related to older versions of software,
@@ -64,6 +69,7 @@ We're working to do some form of cleanup for questions like these. The first ste
 Resolution: @trek will get this list created somehow.
 
 #### Features pending 'Go' decision.
+
 The core team reviewed the following pull requests for future inclusion in the 1.6.x beta series:
 
 *  `ember-routing-named-substates` [#3655](https://github.com/emberjs/ember.js/pull/3655)

--- a/content/core-team-meeting-minutes-2014-02-14.md
+++ b/content/core-team-meeting-minutes-2014-02-14.md
@@ -72,25 +72,25 @@ Resolution: @trek will get this list created somehow.
 
 The core team reviewed the following pull requests for future inclusion in the 1.6.x beta series:
 
-*  `ember-routing-named-substates` [#3655](https://github.com/emberjs/ember.js/pull/3655)
+* `ember-routing-named-substates` [#3655](https://github.com/emberjs/ember.js/pull/3655)
     
       @stefanpenner and @tomdale still need to pow-wow on this.
 
       Resolution: @stefanpenner and @tomdale will speak.
 
-*  `ember-testing-simple-setup` [#3785](https://github.com/emberjs/ember.js/pull/3785)
+* `ember-testing-simple-setup` [#3785](https://github.com/emberjs/ember.js/pull/3785)
 
     @stefanpenner and @tomdale still need to pow-wow on this.
 
     Resolution: @stefanpenner and @tomdale will speak.
 
-*  `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
+* `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
     
     @wycats and @machty continued discussion on lazy loading. Goal is to get it in during this beta cycle
   
     Resolution: @machty & @stefanpenner have a man-date to discuss lazy loading.
 
-*  `composable-computed-properties` [#3696](https://github.com/emberjs/ember.js/pull/3696)
+* `composable-computed-properties` [#3696](https://github.com/emberjs/ember.js/pull/3696)
   
   Still blocked on [computed.literal](https://github.com/emberjs/ember.js/pull/4185)
 
@@ -98,16 +98,16 @@ The core team reviewed the following pull requests for future inclusion in the 1
   Resolution: The original behavior wasn't intended. Changing now might be breaking change
   in some people's apps. We'll put it through a multi-cycle deprecation/removal path.
 
-*  `ember-metal-computed-empty-array` [#4219](https://github.com/emberjs/ember.js/pull/4219)
+* `ember-metal-computed-empty-array` [#4219](https://github.com/emberjs/ember.js/pull/4219)
 
   Resolution: "Go". Upgrade to a Bugfix is it doesn't require a flag.
 
-*  `ember-runtime-test-friendly-promises` [#4176](https://github.com/emberjs/ember.js/pull/4176)
+* `ember-runtime-test-friendly-promises` [#4176](https://github.com/emberjs/ember.js/pull/4176)
 
   Resolution: Peter will try in [Skylight](https://www.skylight.io/)'s tests and
   offer feedback
 
-*  `ember-routing-inherits-parent-model` [#4246](https://github.com/emberjs/ember.js/pull/4246)
+* `ember-routing-inherits-parent-model` [#4246](https://github.com/emberjs/ember.js/pull/4246)
 
   Resolution: Already conceptually a "Go". @machty will make nestable routes in the next week or so so this can be merged.
 

--- a/content/core-team-meeting-minutes-2014-02-21.md
+++ b/content/core-team-meeting-minutes-2014-02-21.md
@@ -72,7 +72,7 @@ the 1.6.x beta series:
     Resolution: Not ready just yet. We don’t  want to serialize default values into the
     URL. False params should be represented as “=false”, rather than merely being absent
     from URL (which was ambiguous). So, this example JSBin from the docs is wrong:
-    http://emberjs.jsbin.com/ucanam/2708.
+    [http://emberjs.jsbin.com/ucanam/2708](http://emberjs.jsbin.com/ucanam/2708).
 
 
 

--- a/content/core-team-meeting-minutes-2014-02-21.md
+++ b/content/core-team-meeting-minutes-2014-02-21.md
@@ -20,11 +20,14 @@ If you have a topic you'd like to see covered, contact your favorite
 core team member and let them know!
 
 #### Attendees
+
 @ebryn, @krisselden, @machty, @tomdale, @trek, @wagenet, @wycats
 
 
 ### Topics
+
 #### Old Stack Overflow questions
+
 Last week we started the process of cleaning up old questions on Stack Overflow by
 collecting a list of questions and evaluating whether the question still made
 sense and, if so, whether selected answer was still the best available answer.
@@ -39,9 +42,11 @@ If you're looking to help, please [check out this document](https://docs.google.
 and give us feedback on some older Stack Overflow questions and answers!
 
 #### ES6ifying core
+
 This work continues [here](https://github.com/emberjs/ember.js/pull/4374).
 
 #### Features pending 'Go' decision.
+
 The core team reviewed the following pull requests for future inclusion in
 the 1.6.x beta series:
 

--- a/content/core-team-meeting-minutes-2014-02-21.md
+++ b/content/core-team-meeting-minutes-2014-02-21.md
@@ -51,7 +51,7 @@ The core team reviewed the following pull requests for future inclusion in
 the 1.6.x beta series:
 
 
-*  `ember-testing-simple-setup` [#3785](https://github.com/emberjs/ember.js/pull/3785)
+* `ember-testing-simple-setup` [#3785](https://github.com/emberjs/ember.js/pull/3785)
 
     While its heart is in the right place, we think this is a bandaid on top of a
     testing infrastructure that needs a bottoms-up rethink.
@@ -64,7 +64,7 @@ the 1.6.x beta series:
 
 
 
-*  `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
+* `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
 
     @stefanpenner and @machty met in person on Tuesday to discuss an API that supported
     lazy loading of routes and will continue the conversation as these changes are made.

--- a/content/core-team-meeting-minutes-2014-02-28.md
+++ b/content/core-team-meeting-minutes-2014-02-28.md
@@ -70,19 +70,19 @@ Resolution:
 The core team reviewed the following pull requests for future inclusion in
 the 1.6.x beta series:
 
-*  `ember-routing-named-substates` [#3655](https://github.com/emberjs/ember.js/pull/3655)
+* `ember-routing-named-substates` [#3655](https://github.com/emberjs/ember.js/pull/3655)
     Still blocked on module vs global object lookup form, which causes naming collisions.
 
     Resolution: will remain on canary until we've moved to modules and have a modular
     loader.
 
-*  `ember-handlebars-caps-lookup` [#3218](https://github.com/emberjs/ember.js/pull/3218)
+* `ember-handlebars-caps-lookup` [#3218](https://github.com/emberjs/ember.js/pull/3218)
     The original author has become unresponsive.
 
     Resolution: approach @mixonic to take over.
 
 
-*  `ember-routing-add-model-option` [#4293](https://github.com/emberjs/ember.js/pull/4293)
+* `ember-routing-add-model-option` [#4293](https://github.com/emberjs/ember.js/pull/4293)
 
     Resolution: It’s a go.
 

--- a/content/core-team-meeting-minutes-2014-02-28.md
+++ b/content/core-team-meeting-minutes-2014-02-28.md
@@ -20,10 +20,13 @@ If you have a topic you'd like to see covered, contact your favorite
 core team member and let them know!
 
 #### Attendees
+
 @ebryn, @krisselden, @machty, @rwjblue, @stefanpenner, @tomdale, @trek, @wycats
 
 ### Topics
+
 #### Hello, Ghost
+
 A few weeks ago [@jacob4u2 reached out over twitter](https://twitter.com/jacob4u2/status/434059022220541952)
 to let us know the popular Node.js-based blogging platform [Ghost](https://ghost.org/) was looking to
 reinvent their admin interface and were discussing various browser JavaScript libraries. The
@@ -45,6 +48,7 @@ Resolution:
 
 
 #### ES6ifying core
+
 The migration of ember-metal, ember-runtime, and ember-debug to ES6-style modules is
 [completed but not yet merged](https://github.com/emberjs/ember.js/pull/4374).  In making
 large changes we're always especially cautious about accidentally breaking existing
@@ -62,6 +66,7 @@ Resolution:
 
 
 #### Features pending 'Go' decision.
+
 The core team reviewed the following pull requests for future inclusion in
 the 1.6.x beta series:
 

--- a/content/core-team-meeting-minutes-2014-03-07.md
+++ b/content/core-team-meeting-minutes-2014-03-07.md
@@ -152,7 +152,6 @@ core team member and let them know!
     > changed upstream (in Handlebars itself), but as I reviewed (to let you know where that change
     > would be needed) I realized that this PR is simply exposing the functionality that already
     > exists within Handlebars, but is not exposed to `Ember.Handlebars.precompile`.
-
     > As such, I think that we should likely re-evaluate the prior decision.
 
     Resolution. Ship it. This just passes from Handlebars to Ember.Handlebars

--- a/content/core-team-meeting-minutes-2014-03-07.md
+++ b/content/core-team-meeting-minutes-2014-03-07.md
@@ -27,7 +27,7 @@ core team member and let them know!
 
 #### Features pending 'Go' decision. [Tracking Issue](https://github.com/emberjs/ember.js/issues/4052)
 
-*  `ember-routing-add-model-option` [#4293](https://github.com/emberjs/ember.js/pull/4293)
+* `ember-routing-add-model-option` [#4293](https://github.com/emberjs/ember.js/pull/4293)
     Resolution: Go
 
 ### PR's/Issues To Review

--- a/content/core-team-meeting-minutes-2014-03-07.md
+++ b/content/core-team-meeting-minutes-2014-03-07.md
@@ -20,6 +20,7 @@ If you have a topic you'd like to see covered, contact your favorite
 core team member and let them know!
 
 #### Attendees
+
 @ebryn, @krisselden, @machty, @rwjblue, @stefanpenner, @tomdale, @trek, @wycats
 
 ### Topics

--- a/content/core-team-meeting-minutes-2014-03-07.md
+++ b/content/core-team-meeting-minutes-2014-03-07.md
@@ -75,7 +75,7 @@ core team member and let them know!
         pressing the back button will be "sticky" since the previous values on the controller will be
         restored based on the previous URL.
 
-      Example JSBin: http://emberjs.jsbin.com/ucanam/4102
+      Example JSBin: [http://emberjs.jsbin.com/ucanam/4102](http://emberjs.jsbin.com/ucanam/4102)
 
       Resolution: Sticky by default, with appropriate escape valves to opt out per route change
 

--- a/content/core-team-meeting-minutes-2014-03-07.md
+++ b/content/core-team-meeting-minutes-2014-03-07.md
@@ -45,6 +45,7 @@ core team member and let them know!
     ```
 
     or
+
     ```
     /blog/somepost?comments=true
     then navigate to
@@ -55,6 +56,7 @@ core team member and let them know!
     ```
 
     Possible opt-out via helper?
+
     ```
     {{link-to ‘Home’ ‘home’ (query-params sort=null)}}
     ```

--- a/content/core-team-meeting-minutes-2014-03-14.md
+++ b/content/core-team-meeting-minutes-2014-03-14.md
@@ -20,16 +20,19 @@ If you have a topic you'd like to see covered, contact your favorite
 core team member and let them know!
 
 #### Attendees
+
 @ebryn, @krisselden, @machty, @rwjblue, @stefanpenner, @tomdale, @trek, @wycats
 
 ### Topics
 
 ### Go/No-Go Feature Listing
+
 *  `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
      Still a no-go, while @machty and @wycats hash out the specifics
 
 
 ### PR's/Issues To Review
+
 * [canSetInnerHTML: IE cannot set innerHTML on several tags](https://github.com/emberjs/ember.js/pull/4496)
 
   IE doesn't support .innerHTML = on COL, COLGROUP, FRAMESET, HTML, STYLE, TABLE, TBODY, TFOOT, THEAD, TITLE, or TR.

--- a/content/core-team-meeting-minutes-2014-03-14.md
+++ b/content/core-team-meeting-minutes-2014-03-14.md
@@ -27,7 +27,7 @@ core team member and let them know!
 
 ### Go/No-Go Feature Listing
 
-*  `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
+* `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
      Still a no-go, while @machty and @wycats hash out the specifics
 
 

--- a/content/core-team-meeting-minutes-2014-03-14.md
+++ b/content/core-team-meeting-minutes-2014-03-14.md
@@ -48,7 +48,7 @@ core team member and let them know!
   My concern is the modification in this particular code path.
 
   Resolution: this used to be how create worked, but we moved away with this for performance reasons. `.extend`
-  is intended for design-time use, not runtime: use `.extend().create() or `.createWithMixins()`
+  is intended for design-time use, not runtime: use `.extend().create()` or `.createWithMixins()`
 
 * [Use injected test helpers instead of local functions.](https://github.com/emberjs/ember.js/pull/4520)
 

--- a/content/core-team-meeting-minutes-2014-03-21.md
+++ b/content/core-team-meeting-minutes-2014-03-21.md
@@ -19,11 +19,13 @@ If you have a topic you'd like to see covered, contact your favorite
 core team member and let them know!
 
 #### Attendees
+
 @ebryn, @krisselden, @machty, @rwjblue, @stefanpenner, @trek, @wycats, @wifelette
 
 ### Topics
 
 #### PRs/Issues To Review
+
 We reviewed the following PRs and Issues:
 
 *  `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)

--- a/content/core-team-meeting-minutes-2014-03-21.md
+++ b/content/core-team-meeting-minutes-2014-03-21.md
@@ -35,7 +35,7 @@ We reviewed the following PRs and Issues:
 
 * Move instanceMetas into object's meta [#4559](https://github.com/emberjs/ember.js/pull/4559)
 
-    InstanceMetas for objects' ReduceComputedPropertys are stored on the RCP instance (ie. on the descriptor) as `this._instanceMetas[key]` where key = guidOfTheObject + ':' + propertyName (see http://git.io/t9bKxA). The RCP can't know when the object is garbage collected, hence the _instanceMetas array grows unbounded.
+    InstanceMetas for objects' ReduceComputedPropertys are stored on the RCP instance (ie. on the descriptor) as `this._instanceMetas[key]` where key = guidOfTheObject + ':' + propertyName (see [http://git.io/t9bKxA](http://git.io/t9bKxA)). The RCP can't know when the object is garbage collected, hence the _instanceMetas array grows unbounded.
 
     Resolution: if David Hamilton +1’s, we merge as a bugfix.
 

--- a/content/core-team-meeting-minutes-2014-03-21.md
+++ b/content/core-team-meeting-minutes-2014-03-21.md
@@ -28,7 +28,7 @@ core team member and let them know!
 
 We reviewed the following PRs and Issues:
 
-*  `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
+* `query-params-new` [#4008](https://github.com/emberjs/ember.js/pull/4008)
 
     Nothing new here. We're working very hard to get this correct the first time
     and have something to demo at EmberConf.

--- a/content/core-team-meeting-minutes-2014-04-04.md
+++ b/content/core-team-meeting-minutes-2014-04-04.md
@@ -31,7 +31,7 @@ core team member and let them know!
 
   Fixes setting of `undefined` value to a content property. 
 
-  Still, checking `obj[keyName] === value` in these [lines] (https://github.com/selvagsz/ember.js/blob/master/packages_es6/ember-metal/lib/property_set.js#L52-54) is bypassed in two cases
+  Still, checking `obj[keyName] === value` in these [lines](https://github.com/selvagsz/ember.js/blob/master/packages_es6/ember-metal/lib/property_set.js#L52-54) is bypassed in two cases
 
     * If the setter value is `undefined`
     * If the setter property lies inside the proxied content

--- a/content/core-team-meeting-minutes-2014-04-04.md
+++ b/content/core-team-meeting-minutes-2014-04-04.md
@@ -19,6 +19,7 @@ If you have a topic you'd like to see covered, contact your favorite
 core team member and let them know!
 
 #### Attendees
+
 [@ebryn](https://twitter.com/ebryn), [@krisselden](https://twitter.com/krisselden), [@machty](https://twitter.com/machty),
 [@rwjblue](https://twitter.com/rwjblue), [@wagenet](https://twitter.com/wagenet), [@tomdale](https://twitter.com/tomdale)
 

--- a/content/core-team-meeting-minutes-2014-04-25.md
+++ b/content/core-team-meeting-minutes-2014-04-25.md
@@ -58,11 +58,11 @@ and better declare and manage our external dependencies.
 
 ### PR's/Issues To Review
 
-*  `ember-routing-linkto-target-attribute` [#4718](https://github.com/emberjs/ember.js/pull/4718)
+* `ember-routing-linkto-target-attribute` [#4718](https://github.com/emberjs/ember.js/pull/4718)
 
     Resolution: Good to merge into Canary, but not a "Go" yet.
 
-*  `ember-routing-will-change-hooks` [#4760](https://github.com/emberjs/ember.js/pull/4760)
+* `ember-routing-will-change-hooks` [#4760](https://github.com/emberjs/ember.js/pull/4760)
 
     Resolution: Good to merge into Canary, but not a "Go" yet.
 

--- a/content/core-team-meeting-minutes-2014-04-25.md
+++ b/content/core-team-meeting-minutes-2014-04-25.md
@@ -44,6 +44,7 @@ core team member and let them know!
 ### Topics
 
 ### Build Tools Redux Progresss
+
 When Ember.js took its first tentative steps into the world there existed no
 ecosystem of build tools for ambitious applications in the browser. Instead,
 we needed to [build these tools](https://github.com/livingsocial/rake-pipeline)

--- a/content/core-team-meeting-minutes-2014-06-06.md
+++ b/content/core-team-meeting-minutes-2014-06-06.md
@@ -41,6 +41,7 @@ core team member and let them know!
 [@tomdale](https://twitter.com/tomdale)
 
 ### Where have all the minutes gone, long time passing?
+
 Many people have reached out on twitter wondering where the meeting
 minutes for May have gone. We'd like to apologize: many of us were
 traveling, attending conferences, and/or handling cross-state moves during May.
@@ -48,6 +49,7 @@ Meetings have still been taking place, topics discussed, and advanced thought
 leadership generated, but attendance and note taking have been sporadic.
 
 ### Ember 1.6/1.7.beta Delayed
+
 We've been delaying the release of Ember 1.6 and the start of the 1.7.beta
 branch for a few weeks to address outstanding issues that have been reported
 and to ensure certain features make it into the 1.7.beta cycle.
@@ -55,6 +57,7 @@ and to ensure certain features make it into the 1.7.beta cycle.
 There are two main concerns:
 
 #### Module Performance Regression
+
 Despite what the anti-framework crowd might think, Ember.js was written from the
 start to be composed of many smaller, single purpose modules. Some of these are
 pulled in from external repositories and some are contained inside
@@ -80,6 +83,7 @@ able to output a build that does not require a loader for Ember.js internals. Ev
 should be sure to thank [Brian Donovan](https://twitter.com/eventualbuddha) and [Square](https://twitter.com/squareeng) for their amazing work on bringing ES6 modules to us today.
 
 #### Query Parameters
+
 When we released 1.0 we pledged to follow [Semantic Versioning](http://semver.org/) and not break public-facing API until 2.0. Because of this, we're hesitant to release extensions to Ember.js's
 public API until we feel confident supporting it for the foreseeable future. We've taken several stabs
 at adding query parameters to our router. People have been very happy with the [latest incarnation](/guides/routing/query-params/) available on canary builds, but there have been a few

--- a/content/core-team-meeting-minutes-2014-06-13.md
+++ b/content/core-team-meeting-minutes-2014-06-13.md
@@ -38,11 +38,13 @@ core team member and let them know!
 [@stefanpenner](https://twitter.com/stefanpenner)
 
 ### Query parameters
+
 This has been [enabled by default](https://github.com/emberjs/ember.js/commit/4130e556132eabad11aa619092c8ea840ba4957b)
 in beta and nightly builds. Check out [Query Parameters Guide](/guides/routing/query-params/)
 for usage details.
 
 ### Keeping the train moving
+
 In the last meeting we discussed why the release of 1.6 and 1.7.beta was delayed.
 In this meeting we resolved to not delay releases just because we hope to include
 a specific feature. 

--- a/content/core-team-meeting-minutes-2014-06-27.md
+++ b/content/core-team-meeting-minutes-2014-06-27.md
@@ -42,4 +42,5 @@ core team member and let them know!
 [@wycats](https://twitter.com/wycats)
 
 ### 1.6 and 1.7.beta
+
 We're cutting these today and publishing.

--- a/content/core-team-meeting-minutes-2014-07-11.md
+++ b/content/core-team-meeting-minutes-2014-07-11.md
@@ -41,6 +41,7 @@ core team member and let them know!
 [@wycats](https://twitter.com/wycats)
 
 ### Path to Core
+
 Members of the community who have a sustained and significant contribution to
 Ember.js are invited to join the core team and help us guide the framework's
 future direction. Members we'd like to add are put on the "path to core" and

--- a/content/core-team-meeting-minutes-2014-07-25.md
+++ b/content/core-team-meeting-minutes-2014-07-25.md
@@ -44,22 +44,26 @@ core team member and let them know!
 [@wycats](https://twitter.com/wycats)
 
 ### Face to Face July 2014
+
 Last week the core team (and those on path to core) met in New York City for
 our periodic face to face meeting. Tom and Yehuda will be posting notes from
 that meeting in the coming weeks. Thank you to our friends at [Pivotal
 Labs](http://pivotallabs.com/) for hosting us in their awesome new office.
 
 ### Built With Ember
+
 A few months ago we [began tracking](https://docs.google.com/document/d/1ZWYq3gwkPTzUiyqr4x_asSj8wIgfvg8XyLmU3Yx_FPE/edit) some of the ambitious apps made
 with Ember.js. The folks at [Blimp](http://www.getblimp.com/) have turned that
 document into a curated list of awesome Ember.js applications. [Check it
 out](http://builtwithember.io/).
 
 ### ember-cli website
+
 `ember-cli`, our ES6 module-based build tool has a new site. [Give it a
 browse](http://www.ember-cli.com/)
 
 ### Modularizing Ember.js's Repository
+
 We've started moving more external dependencies out of the Ember.js repository
 and have begun work to turn some infrequently used parts of the framework into
 their own libraries. These will still be built into the `1.x` series of

--- a/content/core-team-meeting-minutes-2014-08-01.md
+++ b/content/core-team-meeting-minutes-2014-08-01.md
@@ -43,6 +43,7 @@ core team member and let them know!
 [@wycats](https://twitter.com/wycats)
 
 ### Revamp the Getting Started Guide
+
 We're starting work to revamp
 our [Getting Started Guide](http://emberjs.com/guides/getting-started/).
 TodoMVC is just too small of an app to demonstrate enough topics. We were
@@ -55,6 +56,7 @@ nested view and data hierarchies, url-driven applications, intuitive
 query paramater behaviors.
 
 ### Deprecating global view lookup from templates
+
 As we move towards a world where ES6 syntax and modules
 become viable we continue to deprecate some "old style"
 globals lookup. The following uses will all trigger

--- a/content/core-team-meeting-minutes-2014-08-14.md
+++ b/content/core-team-meeting-minutes-2014-08-14.md
@@ -57,7 +57,7 @@ Currently the Guides and API are not versioned, which increasingly leads to
 pain around new feature documentation. The plan is to beging publishing guides
 and API to a subdomains and version them:
 
-* http://guides.emberjs.com/ (defaults to latest)
-* http://guides.emberjs.com/1.8
-* http://api.ember.js.com/ (defaults to latest)
-* http://api.ember.js.com/1.8
+* [http://guides.emberjs.com/](http://guides.emberjs.com/) (defaults to latest)
+* [http://guides.emberjs.com/1.8](http://guides.emberjs.com/1.8)
+* [http://api.ember.js.com/](http://api.ember.js.com/) (defaults to latest)
+* [http://api.ember.js.com/1.8](http://api.ember.js.com/1.8)

--- a/content/core-team-meeting-minutes-2014-08-14.md
+++ b/content/core-team-meeting-minutes-2014-08-14.md
@@ -46,11 +46,13 @@ core team member and let them know!
 [@wycats](https://twitter.com/wycats)
 
 ### Explore using Lodash
+
 We reviewed a [PR that replaces Ember builtin array extensions internals with Lodash](https://github.com/emberjs/ember.js/pull/5019).
 
 Assuming no performance regressions, we're in favor.
 
 ### Guides and API versioned and subdomained
+
 Currently the Guides and API are not versioned, which increasingly leads to
 pain around new feature documentation. The plan is to beging publishing guides
 and API to a subdomains and version them:

--- a/content/core-team-meeting-minutes-2014-09-12.md
+++ b/content/core-team-meeting-minutes-2014-09-12.md
@@ -46,6 +46,7 @@ core team member and let them know!
 
 
 ### HTMLBars
+
 Most of this weeks discussion focused on our largest ongoing project: HTMLBars.
 We're hoping HTMLBars is on track to make it into the 1.9 or 1.10 beta series.
 

--- a/content/countdown-to-the-new-year-ember-mapbox-gl.md
+++ b/content/countdown-to-the-new-year-ember-mapbox-gl.md
@@ -31,6 +31,7 @@ Yes, it's satisfying to solve the problem yourself, but it's smarter—and quick
 say, [building your own file uploader](https://emberobserver.com/?query=file%20upload).
 
 A cursory glance at the available mapping addons show up a few options:
+
 - [ember-mapbox-gl](https://github.com/kturney/ember-mapbox-gl) (Full disclosure: I'm a contributor, although [kturney](https://github.com/kturney) does most of the work!)
 - [ember-leaflet](https://github.com/miguelcobain/ember-leaflet)
 - [ember-google-maps](https://github.com/sandydoo/ember-google-maps)

--- a/content/ember-1-8-1-released.md
+++ b/content/ember-1-8-1-released.md
@@ -46,8 +46,8 @@ in a number of modules, and we have expanded our work around for more modules in
 
 Further Reading:
 
-- https://bugs.webkit.org/show_bug.cgi?id=138038
-- https://github.com/emberjs/ember.js/issues/5606
+- [https://bugs.webkit.org/show_bug.cgi?id=138038](https://bugs.webkit.org/show_bug.cgi?id=138038)
+- [https://github.com/emberjs/ember.js/issues/5606](https://github.com/emberjs/ember.js/issues/5606)
 
 ### Support rendering of null-prototype objects
 

--- a/content/ember-2019-roadmap-call-for-posts.md
+++ b/content/ember-2019-roadmap-call-for-posts.md
@@ -28,6 +28,7 @@ The 2018 Roadmap led to the ["Octane Edition" of Ember, currently in preview](ht
 To contribute a post: Tweet a link to the post with the hashtag #EmberJS2019 or email a link to roadmap@emberjs.com. These posts will be collected and categorized, and each one will be read by those working to draft the Roadmap RFC.
 
 ### _Format_
+
 Your post can be on any online writing platform, but we suggest:
 
 * A post on your personal or company blog

--- a/content/ember-3-10-released.md
+++ b/content/ember-3-10-released.md
@@ -27,6 +27,7 @@ You can read more about our general release process here:
 Ember.js is the core framework for building ambitious web applications.
 
 ### Changes in Ember.js 3.10
+
 Ember.js 3.10 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There are four (4) new features, one (1) deprecations, and seventeen (17) bugfixes in this version.
 
 #### New Features (4)

--- a/content/ember-3-11-released.md
+++ b/content/ember-3-11-released.md
@@ -112,6 +112,7 @@ export default Component.extend({
   })
 }
 ```
+
 ```hbs
 Current count: {{this.count}}
 

--- a/content/ember-3-11-released.md
+++ b/content/ember-3-11-released.md
@@ -26,6 +26,7 @@ You can read more about our general release process here:
 Ember.js is the core framework for building ambitious web applications.
 
 ### Changes in Ember.js 3.11
+
 Ember.js 3.11 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There are four (4) new features, one (1) deprecation, and several bugfixes in this version.
 
 #### New Features (4)

--- a/content/ember-3-4-released.md
+++ b/content/ember-3-4-released.md
@@ -114,6 +114,7 @@ export default {
  initialize
 };
 ```
+
 Next, you can create a new component class depending on this component manager using the `setComponentManager` util as follows:
 
 ```js

--- a/content/ember-3-6-released.md
+++ b/content/ember-3-6-released.md
@@ -30,6 +30,7 @@ You can read more about our general release process here:
 Ember.js is the core framework for building ambitious web applications.
 
 ### Changes in Ember.js 3.6
+
 Ember.js 3.6 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There are 2 new features, 6 deprecations, and 13 bugfixes in this version.
 
 #### New Features (2)
@@ -199,10 +200,12 @@ To update your project you need to run the following steps:
 ### Changes in Ember CLI 3.6
 
 #### New Features (1)
+
 **Prevent double builds in CI (1 of 1)**
 Until version 3.6 the addon author (unless the addon was in an org) would always end up with two CI builds for every PR. One for the branch push and one for the PR update. This is now fixed in Ember CLI 3.6 (for TravisCI users).
 
 #### Deprecations (0)
+
 There's no deprecations in this version.
 
 ---

--- a/content/ember-3-7.md
+++ b/content/ember-3-7.md
@@ -27,6 +27,7 @@ You can read more about our general release process here:
 Ember.js is the core framework for building ambitious web applications.
 
 ### Changes in Ember.js 3.7
+
 Ember.js 3.7 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There is zero (0) new feature, zero (0) deprecations, and three (3) bugfixes in this 3.7 version.
 
 Note that in Ember.js 3.7 support for Node 4 has been explicitly dropped. Node 4 is no longer supported by the Node.js team either, and that Ember CLI had already dropped support in early 2018. This means that if you are on Node 4 and want to upgrade you will need to upgrade your version of Node first.

--- a/content/ember-3-9-released.md
+++ b/content/ember-3-9-released.md
@@ -28,9 +28,11 @@ Additionally, versions 3.8 of Ember and Ember Data are now promoted to LTS, whic
 Ember.js is the core framework for building ambitious web applications.
 
 ### Changes in Ember.js 3.9
+
 Ember.js 3.9 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There are zero (0) new features, six (6) deprecations, and eight (8) bugfixes in this version.
 
 #### New Features (0)
+
 No new features introduced in Ember.js 3.9.
 
 #### Deprecations (6)

--- a/content/ember-accessibility-and-a11y-tools.md
+++ b/content/ember-accessibility-and-a11y-tools.md
@@ -146,6 +146,7 @@ While ember-a11y refers to a whole bunch of tools, there's one addon that is sim
 ```
 ember install ember-a11y
 ```
+
 Install it and replace instances of `{{outlet}}` with 
 `{{focusing-outlet}}`.
 

--- a/content/ember-data-1-0-beta-18-released.md
+++ b/content/ember-data-1-0-beta-18-released.md
@@ -16,9 +16,9 @@ patches!
 
 While many bugs were stomped, some important changes are worth calling out:
 
-# (Possibly) Breaking Deprecations
+## (Possibly) Breaking Deprecations
 
-## record.constructor.typeKey is now record.constructor.modelName
+### record.constructor.typeKey is now record.constructor.modelName
 
 In Ember Data, when you ask for a model, Ember Data looks its class up using
 Ember's [Dependency Injection][dep-inj] API.  When the model class is looked
@@ -63,7 +63,7 @@ We changed `typeKey` to `modelName` to allow us to align to dasherized strings
 as Ember and Ember CLI also align with dasherized strings. Changing the name
 allows us to make this change with a deprecation phase.
 
-## DS.RESTSerializer.typeForRoot is now DS.RESTSerializer.modelNameFromPayloadKey
+### DS.RESTSerializer.typeForRoot is now DS.RESTSerializer.modelNameFromPayloadKey
 
 To gain more consistency in the naming change of  `typeKey` to `modelName`,
 `typeForRoot` has been renamed to `modelNameFromPayloadKey`. The function
@@ -71,9 +71,9 @@ serves the same purpose, so this should be a quick refactor you can achieve via
 search and replace in your project. While *calling* typeForRoot will trigger a
 deprecation warning, overriding in a subclass won't.
 
-# New Features
+## New Features
 
-## DS.RESTSerializer.payloadKeyFromModelName
+### DS.RESTSerializer.payloadKeyFromModelName
 
 While `modelNameFromPayloadKey` returns a *model* for a JSON payload key,
 `payloadKeyFromModelName` can be used to override the serialization of a model
@@ -109,14 +109,14 @@ While this was possible previously in Ember Data, we noticed that users used
 several different hooks to achieve this goal, so it made sense to make one
 unifying place for this kind of serialization.
 
-## store.unloadAll() can now unload all models when not passed a modelName
+### store.unloadAll() can now unload all models when not passed a modelName
 
 Previously, `store.unloadAll` required a `modelName` argument to unload records
 of a type.  Now, you can unload all records without calling `store.destroy`.
 Thanks to [svox1](https://github.com/emberjs/data/pull/2999) for this pull
 request!
 
-## DS.RESTAdapter.buildURL refactored into different hooks
+### DS.RESTAdapter.buildURL refactored into different hooks
 
 `buildURL` has been refactored into several hooks like `urlForFindQuery`. This
 makes overriding methods like `buildURL` easier to reason about and easier to

--- a/content/ember-data-1-0-beta-9-released.md
+++ b/content/ember-data-1-0-beta-9-released.md
@@ -300,6 +300,7 @@ Stef landing some commits on improving `pushPayload` calls and a [commit
 to Backburner][backburner-commit] improving many hot code paths in Ember Data.
 
 ### Better Support for Nested Records.
+
 `buildURL` now takes a record, on which you can look up the relationship if you
 need to build a nested URL. For example:
 

--- a/content/ember-data-1-13-released.md
+++ b/content/ember-data-1-13-released.md
@@ -620,6 +620,7 @@ underlying implementation and will allow us to easily use methods like
 in the future.
 
 ### Using JSON API Error object format
+
 Similarly to the rest of Ember Data 1.13, we have refactored the error handling to use JSON API. JSON API has specified an
 [error objects](http://jsonapi.org/format/#error-objects)
 format. Starting with Ember Data 1.13 we are using JSON API format to

--- a/content/ember-data-2-0-released.md
+++ b/content/ember-data-2-0-released.md
@@ -96,7 +96,7 @@ App.PostController = Ember.Controller.extend({
 });
 ```
 
-# Ember Data 2.1 Beta
+## Ember Data 2.1 Beta
 
 Ember Data data 2.1 will be the first release following Ember's 6 week
 release cycle. Rather then rush new features into the beta before they

--- a/content/ember-data-2-3-released.md
+++ b/content/ember-data-2-3-released.md
@@ -112,9 +112,11 @@ module API.
 #### Notable Bug Fixes
 
 ##### [PR #4025 Use keyForRelationship for belongsTo and hasMany](https://github.com/emberjs/data/pull/4025/)
+
 The `EmbeddedRecordsMixin` now uses [keyForRelationship](http://emberjs.com/api/data/classes/DS.RESTSerializer.html#method_keyForRelationship) to generate the serialized key for embedded relationships. Thanks to [@GCorbel](https://github.com/GCorbel) for this fix.
 
 ##### [PR #3866 Allow store.push to accept { data: null }](https://github.com/emberjs/data/pull/3866)
+
 The JSONAPISerializer now correctly accepts `{"data": null}` as a valid response instead of throwing an unhelpful error message. Thanks to [@mitchlloyd](https://github.com/mitchlloyd) for the [bug report](https://github.com/emberjs/data/issues/3790).
 
 

--- a/content/ember-data-2-4-released.md
+++ b/content/ember-data-2-4-released.md
@@ -144,6 +144,7 @@ the transform.
 
 
 ##### Example
+
 ```app/models/post.js
 export default DS.Model.extend({
   title: DS.attr('string'),

--- a/content/ember-data-2-5-released.md
+++ b/content/ember-data-2-5-released.md
@@ -112,6 +112,7 @@ the transform.
 
 
 ##### Example
+
 ```app/models/post.js
 export default DS.Model.extend({
   title: DS.attr('string'),

--- a/content/ember-data-meeting-minutes-2014-06-25.md
+++ b/content/ember-data-meeting-minutes-2014-06-25.md
@@ -34,6 +34,7 @@ discussion of all things Ember-Data.
 [@terzicigor](https://twitter.com/terzicigor)
 
 ### Serializer refactor
+
 We discussed how best to refactor the existing serializers, especially the work lead by [@BMac](https://twitter.com/BezoMaxo) to break up the
 Rest Serializer into a JSON Serializer + a Sideloading mixin. While working on it, there were several issues raised, including the problem of
 how to make sure that mixins that extend the JSON Serializer(Embedded records mixin right now, and Sideloading mixin in the future) have their
@@ -44,6 +45,7 @@ Tom raised the idea of having a serialization pipeline, but we decided to punt o
 Decided to wait on more use cases before deciding whether/and how to reorganize the hooks such that mixins are easier to use/write.
 
 ### Zalgo Promise Proxy
+
 Discussed how to address the problem of serializing async relationships.
 [@terzicigor](https://twitter.com/terzicigor) and [@stefanpenner](https://twitter.com/stefanpenner) have previously come up with the idea of having
 a Zalgo Proxy, a proxy that would be passed to the serialize hook and would proxy access to relationships as synchronous.
@@ -59,10 +61,12 @@ Decided to make template bindings work with promises, while not letting users ma
 Will require some Ember-Metal work to get working
 
 ### Explore a way for nicely getting a sync version of a model
+
 Decided to explore a nice way of calling then on a model and/or several relationships at once which would return a promise
 that would resolve once all the relationships are loaded.
 
 ### Think about how to incorporate async wait from ES7
+
 [@wycats](https://twitter.com/wycats) was very excited about the possibility of having Ember-Data support async wait from ES7.
 Said it could make dealing with asynchronicity much nicer. No conclusion, due to a lack of time for someone to investigate.
 

--- a/content/ember-data-meeting-minutes-2014-07-02.md
+++ b/content/ember-data-meeting-minutes-2014-07-02.md
@@ -35,6 +35,7 @@ discussion of all things Ember-Data.
 [@terzicigor](https://twitter.com/terzicigor)
 
 ### PushPayload discussion
+
 We discussed the [PushPayload proposal](http://discuss.emberjs.com/t/adding-a-function-to-ed-store-to-normalize-push-a-single-type/5321)
 
 @wycats concluded that the original decision for `pushPayload` on the store to accept a `type` argument was a mistake.
@@ -47,6 +48,7 @@ Thus instead of doing `pushAndNormalize` from the discuss proposal, one can do
 It also seems nice to have a `normalize` method on the store as the inverse of `serialize` which already exists on the model.
 
 ### Group Coalescing
+
 [@hjdivad](https://twitter.com/hjdivad) and [@terzicigor](https://twitter.com/terzicigor) recently added a
 [groupedRecordsForFindMany](https://github.com/emberjs/data/commit/60b518e5b012c9dc1427256d635f46fc91bee019) hook on the findCoalescing
 branch to enable users to decide how to group coalesced requests.

--- a/content/framework-f2f.md
+++ b/content/framework-f2f.md
@@ -37,14 +37,17 @@ One of the framework’s main strengths is that Ember apps have uncommon longevi
 To learn more about Octane and how these RFCs work to support it, see the [2018 Roadmap RFC](https://github.com/emberjs/rfcs/pull/364) by Tom Dale, which introduces Octane, and the [Editions RFC](https://github.com/emberjs/rfcs/pull/371) by Dave Wasmer.
 
 ## Review of website improvement progress
+
 There is an opportunity to refresh and renew more than our APIs. As previously described in [The Ember Times](https://the-emberjs-times.ongoodbits.com/), significant work is underway to improve the architecture, look, and feel of our public website, [emberjs.com](https://emberjs.com). Framework core team members received an update on the latest progress, which is now an [RFC open to public review](https://github.com/emberjs/rfcs/pull/425). Over the past year, many pieces of the multiple web apps that make up our public site have been refactored to use a central style guide and common UI components, making the upcoming visual refactor possible. This work has been done in [ember-styleguide](https://github.com/ember-learn/ember-styleguide). 
 
 There has been major progress in accessibility, consistency, and better marketing messaging of the site, but there’s still more work to do! The Learning Team and the Website Strike team are on the job. Stay tuned for more updates in the new year.
 
 ## Action items
+
 It’s safe to say that there’s a lot of work to do for the features and documentation that make up the Octane edition! To follow along or help out, see the [Octane Tracking Issue](https://github.com/emberjs/ember.js/issues/17234). The new architecture for the public site is a work in progress app found [here](https://github.com/ember-learn/ember-website).
 
 ## What’s next?
+
 Before every [EmberConf](https://emberconf.com/), the largest gathering of Ember devs, there’s always a flurry of activity. It seems like the first quarter of 2019 might be the liveliest one yet! There are less than two months to go, and some big plans underway. Stay tuned for updates via [The Ember Times](https://the-emberjs-times.ongoodbits.com/), the [Ember.js Twitter](https://twitter.com/emberjs), and “watch” the [ember.js GitHub repository](https://github.com/emberjs/ember.js)... if you dare. 
 
 Hope to see you in March at EmberConf!

--- a/content/the-ember-times-issue-100.md
+++ b/content/the-ember-times-issue-100.md
@@ -67,6 +67,7 @@ Please thank [@Alonski](https://github.com/Alonski), [@maxwondercorn](https://gi
 ---
 
 ## [Codemod for ES6 Class Syntax Including Decorators 🤖](https://github.com/ember-codemods/ember-es6-class-codemod)
+
 Excited about the chance to try out the ✨**native decorator support**✨ announced as part of the [release of Ember.js 3.10](https://blog.emberjs.com/2019/05/21/ember-3-10-released.html)? The good news is there's a [codemod](https://github.com/ember-codemods/ember-es6-class-codemod) to help you out with that!
 
 Note that this part of the codemod is a configurable option in the transforms. If set to true, it will transform an object's properties to decorators wherever required. Also note that, unless turned off, this codemod will by default handle transforming object properties to class fields.

--- a/content/the-ember-times-issue-101.md
+++ b/content/the-ember-times-issue-101.md
@@ -64,7 +64,7 @@ He shares three concrete ideas to make growing Ember a reality:
 ) on how “we can iteratively move forward into the future that can actually happen.”
 
 > Having a great packaging system is critical to Ember's success. This wish list is not long, but very important to land and 'get right'. [...] We really need to adopt Embroider!
-
+>
 > The Ember project as a whole needs to get much better about closing the loop on these dead ends, and communicate more clearly with the community so that they can avoid known future pitfalls when developing their ambitious applications.
 
 ---

--- a/content/the-ember-times-issue-52.md
+++ b/content/the-ember-times-issue-52.md
@@ -89,6 +89,7 @@ The RFC states that, in this possible scenario, users would drop `EmberObject` i
 ---
 
 ## [New Tutorial on Accessibility](https://emberjs.com/blog/2018/06/17/ember-accessibility-and-a11y-tools.html)
+
 Ever wondered how to write accessible Ember apps? Jen Weber wrote a [great tutorial](https://emberjs.com/blog/2018/06/17/ember-accessibility-and-a11y-tools.html) explaining all you need to get started. She takes you through setting up `ember-a11y-testing`, a tool made to do automated accessibility testing, adding accessibility checks to rendering tests and how to fix the issues found.
 
 The tutorial ends with a nice section on what to do next. One thing is automated testing but as developers our responsibility is much bigger than that.

--- a/content/the-ember-times-issue-52.md
+++ b/content/the-ember-times-issue-52.md
@@ -41,6 +41,7 @@ by making use of the addon `ember-decorators` - seeing the classy ✨ future of 
 
 Now the follow-up [Native Class Roadmap RFC](https://github.com/emberjs/rfcs/pull/338) from the author of [RFC#240](https://emberjs.github.io/rfcs/0240-es-classes.html) has made its debut.
 It explains how several changes to the current API of `EmberObject`
+
 - including an [update](#toc_a-href-https-github-com-emberjs-rfcs-pull-337-native-class-constructor-update-a) to how the `constructor` method operates -
 will be necessary to make ES Classes true first-class citizens in the Ember ecosystem
 and how `EmberObject` can be safely deprecated in the further future.

--- a/content/the-ember-times-issue-53.md
+++ b/content/the-ember-times-issue-53.md
@@ -40,6 +40,7 @@ Look for this speedup soon in an Ember App near you!
 ---
 
 ## [Oh, No(de) He Didn't!](https://github.com/ef4/ember-auto-import)
+
 [Edward Faulkner](https://github.com/ef4) has just released version 1.0 of `ember-auto-import`. This addon allows you to add dependencies using NPM or Yarn with **zero configuration**. It can be used both in apps and addons and deduplicates correctly across all addons and the app itself.
 
 All you have to do is type `ember install ember-auto-import` and you’re ready to add whatever dependency you want to your project using NPM or yarn.

--- a/content/the-ember-times-issue-54.md
+++ b/content/the-ember-times-issue-54.md
@@ -27,6 +27,7 @@ At last, there's news about **👩‍💻 Twiddle** as well as a nice **📹 vid
 ---
 
 ## [Organising the Organisers](https://emberjs.com/blog/2018/06/30/organizing-our-contributors.html)
+
 The Ember Team has published a new blog post outlining some **structural changes** to the **Core teams**. It contains two changes: A new Steering Committee and a renaming of some of the existing teams.
 
 The Steering Committee will be responsible for areas like community guidelines, managing Ember’s brand, dealing with legal questions and much more.
@@ -96,6 +97,7 @@ next major release. Read all about 👀 it on the Ember Blog:
 ---
 
 ## [Open Source Live](https://www.youtube.com/watch?v=Dx0vfMyQJMU&feature=youtu.be)
+
 Now that the Guides and Deprecations have been moved into Ember apps, [emberjs.com](https://emberjs.com/) needs to be moved to an Ember app too! [Chris Manson](https://github.com/mansona) and [Melanie Sumner](https://github.com/MelSumner) recorded their **latest pairing session**, where they are working on **adding the beta** [ember-learn/ember-styleguide](https://github.com/ember-learn/ember-styleguide) to the new [ember-learn/ember-website](https://github.com/ember-learn/ember-website) (a rewrite of [emberjs/website](https://github.com/emberjs/website) in Ember, so as to make it easier to contribute to). Check out the video to learn more about Learning Team happenings and pair programming for knowledge sharing!
 
 ---

--- a/content/the-ember-times-issue-55.md
+++ b/content/the-ember-times-issue-55.md
@@ -26,6 +26,7 @@ This week you can learn about **updating** your Ember app 💁🏻. Learn from f
 ---
 
 ## [Don't Worry, Ember CLI Got You Covered 💻](https://github.com/ember-cli/ember-cli-update)
+
 The **number one** tool for updating Ember.js apps or addons just got **even better**. The [newest version](https://github.com/ember-cli/ember-cli-update/releases) of `ember-cli-update` now runs `qunit-dom-codemod` for you. This means that you, with close to no effort at all, can utilize this great addon for your tests.
 
 And the cool thing is that `ember-cli-update` fetches new codemods **during runtime** - so no need to update to get this nice codemod! To run the codemod just type `ember-cli-update --run-codemods` and magic will take care of the rest for you.

--- a/content/the-ember-times-issue-59.md
+++ b/content/the-ember-times-issue-59.md
@@ -36,6 +36,7 @@ Read more about his journey at Esteban’s [blog post](https://envoy.engineering
 ---
 
 ## [One Port to Rule Them All 💍](https://github.com/ember-cli/ember-cli/releases/tag/v3.4.0-beta.2)
+
 With `ember-cli@3.4.0-beta.2` you now have the ability to enable the live reloading server and the normal development app server to share a **single port**. With the current state of Ember CLI it opens two HTTP servers - one for the assets and one to support live reloading on file changes.
 
 You can already test this by [getting the beta](https://github.com/ember-cli/ember-cli/releases/tag/v3.4.0-beta.2) and see if it works for you. Remember to also check the rest of the changelog for the beta. And if you're interested in the actual implementation for making the single port work, then check out [the PR](https://github.com/ember-cli/ember-cli/pull/7940).

--- a/content/the-ember-times-issue-60.md
+++ b/content/the-ember-times-issue-60.md
@@ -25,6 +25,7 @@ This week's Ember Times is all about **cool web fonts** 😎, community **chat**
 ---
 
 ## [Taking Web Fonts to the Next Level 🔠](https://github.com/vitch/ember-cli-webfont)
+
 Do you like web fonts? Of course you do! Then it’s a good thing that `ember-cli-webfonts` just released version 1.0 🎉
 
 Now you can use the `webfonts-generator` to **easily generate web fonts** as part of your ember build process. By default the addon expects to find SVG files in `app/webfont-svg` but all of this can be customised alongside with class prefixes, base selectors, font names and much more.

--- a/content/the-ember-times-issue-60.md
+++ b/content/the-ember-times-issue-60.md
@@ -30,7 +30,7 @@ Do you like web fonts? Of course you do! Then it’s a good thing that `ember-cl
 
 Now you can use the `webfonts-generator` to **easily generate web fonts** as part of your ember build process. By default the addon expects to find SVG files in `app/webfont-svg` but all of this can be customised alongside with class prefixes, base selectors, font names and much more.
 
-All you have to do is run `ember install ember-cli-webfont ` and you’re ready to go. Check out the [Github repository](https://github.com/vitch/ember-cli-webfont) for more information.
+All you have to do is run `ember install ember-cli-webfont` and you’re ready to go. Check out the [Github repository](https://github.com/vitch/ember-cli-webfont) for more information.
 
 ---
 

--- a/content/the-ember-times-issue-61.md
+++ b/content/the-ember-times-issue-61.md
@@ -39,6 +39,7 @@ Be sure to [read the original proposal over at Github](https://github.com/emberj
 ---
 
 ## [I'm willing to wait for it 🎶](https://github.com/emberjs/data/pull/5545)
+
 A new PR has been merged to Ember Data that improves your use of `async ... await` while simultaneously detecting asynchronous test leaks in their data layer.
 
 The feature works in non-production environments and they made sure that the test-waiter does not cause waiting by default in order to prevent breaking any apps that upgrade their version of Ember Data.

--- a/content/the-ember-times-issue-61.md
+++ b/content/the-ember-times-issue-61.md
@@ -44,7 +44,7 @@ A new PR has been merged to Ember Data that improves your use of `async ... awai
 
 The feature works in non-production environments and they made sure that the test-waiter does not cause waiting by default in order to prevent breaking any apps that upgrade their version of Ember Data.
 
-This new feature comes with two feature flags `store.shouldTrackAsyncRequests `  and `store.generateStackTracesForTrackedRequests`. To learn all about them and some more information on this new feature, be sure to check out [the pull request](https://github.com/emberjs/data/pull/5545).
+This new feature comes with two feature flags `store.shouldTrackAsyncRequests` and `store.generateStackTracesForTrackedRequests`. To learn all about them and some more information on this new feature, be sure to check out [the pull request](https://github.com/emberjs/data/pull/5545).
 
 ---
 

--- a/content/the-ember-times-issue-61.md
+++ b/content/the-ember-times-issue-61.md
@@ -60,6 +60,7 @@ Melanie mentioned how she practices **Servant Leadership** which she described a
 Sam and Melanie then talked about the native accessibility story for Ember going through the [ARIA spec](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA) and seeing if it makes sense to implement it in Ember. There are loads of opportunities here as even having a modal or select dropdown be both accessible and customizable would be a huge leap for web developers. Having that built into Ember by default will be a game changer.
 
 Click the links below watch the full interview:
+
 - 🎥 [EmberMap](https://embermap.com/topics/the-embermap-podcast/melanie-sumner-on-empowering-javascript-engineers)
 - 🎙️ [iTunes](https://itunes.apple.com/us/podcast/the-embermap-podcast/id1288274408?mt=2)
 - 📺 [YouTube](https://www.youtube.com/watch?v=KXFYNhNgn_Q)

--- a/content/the-ember-times-issue-63.md
+++ b/content/the-ember-times-issue-63.md
@@ -44,6 +44,7 @@ Community action items:
 ---
 
 ## [RFC: Ember Editions](https://github.com/emberjs/rfcs/blob/9c7fe3f4e947b5f79050214334a98673494c25d7/text/0000-editions.md)
+
 [@davewasmer](https://github.com/davewasmer) has written a RFC introducing the concepts of **editions**. The idea is that every few years Ember will declare a new edition of Ember that bundles up accumulated incremental improvements into a cohesive package.
 
 The benefit of this being that this gives the Ember Community an opportunity to bring our documentation and marketing up-to-date to reflect the improvements we’ve made since the previous edition. According to the RFC, the right time to declare a new edition is when:

--- a/content/the-ember-times-issue-66.md
+++ b/content/the-ember-times-issue-66.md
@@ -61,6 +61,7 @@ As always, **leave your comments** and appreciation [below the original proposal
 ---
 
 ## [The Missing Docs Has Returned 📃](https://github.com/emberjs/ember.js/pull/17002)
+
 There has been [some documentation missing](https://github.com/emberjs/ember.js/issues/16993) from the Ember API docs from the release of 3.3 to 3.4. [@Gaurav0](https://github.com/Gaurav0) has done some great detective work 🕵  and [fixed these issues](https://github.com/emberjs/ember.js/pull/17002) which means that **the missing documentation is now back.**
 
 Going forward the plan is to provide better testing for cases like this so you always have access to the documentation you need.

--- a/content/the-ember-times-issue-69.md
+++ b/content/the-ember-times-issue-69.md
@@ -23,6 +23,7 @@ This week we're discussing 4️⃣ fresh RFCs 🥑: bringing truth helpers to Em
 ---
 
 ## [Help Yourselves to Default Template Helpers 🍽️](https://github.com/emberjs/rfcs/pull/388)
+
 If you find yourself often reaching for the addon [ember-truth-helpers](https://github.com/jmurphyau/ember-truth-helpers) in your templates then this [new RFC by @cibernox](https://github.com/emberjs/rfcs/pull/388) is for you. This **Request for Comments (RFC)** proposes bringing in some of the **template helpers** in `ember-truth-helpers` into **Ember Core**.
 
 The reasoning behind this is that a few helpers from this addon are so common in Ember apps that it makes sense to add them into Ember Core itself to **reduce the friction** of needing to install an addon to get them.
@@ -54,6 +55,7 @@ Curious to know more? Here's the [full proposal](https://github.com/emberjs/rfcs
 ---
 
 ## [We've Got You Covered ⛑](https://github.com/emberjs/ember.js/pull/16910)
+
 You might have noticed that sometimes when a new release of Ember is out some API documentation can disappear. This happens when code gets moved around in Ember, such as putting functions in their own modules, which makes it easy to make mistakes that impact the documentation parser. [@ef4](https://github.com/ef4) added [test coverage](https://github.com/emberjs/ember.js/pull/16910) for exactly these cases.
 
 This means that when a new release is prepared these tests will most likely catch any unintentional documentation changes.

--- a/content/the-ember-times-issue-70.md
+++ b/content/the-ember-times-issue-70.md
@@ -28,6 +28,7 @@ This week we have an Ember standard for i18n 🌍, more convenient **transitions
 [@snewcomer](https://github.com/snewcomer) and [@cibernox](https://github.com/cibernox) [announced](https://twitter.com/MiguelCamba/status/1054699605865177089) a new way to internationalize Ember apps, [ember-i18n](https://github.com/jamesarosen/ember-i18n) is now deprecated in favour of [ember-intl](https://github.com/ember-intl/ember-intl)! This will provide Ember with a standard package for internationalization.
 
 There are [many reasons](https://twitter.com/MiguelCamba/status/1054720978478084097) to make the change such as:
+
 - Using the [**ICU message format**](https://formatjs.io/guides/message-syntax/) which is a standard in the i18n industry
 - **Locale-aware** numbers, dates, times, currencies, decimals, and percentages!
 - Uses the [**Native Intl API**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl)

--- a/content/the-ember-times-issue-71.md
+++ b/content/the-ember-times-issue-71.md
@@ -43,6 +43,7 @@ If you would like to **chime in** and join the discussion be sure to check out t
 ---
 
 ## [A New and Dynamic RFC](https://github.com/cibernox/rfcs/blob/dynamic-tag-names/text/0000-dynamic-tag-names.md)
+
 [@cibernox](https://github.com/cibernox) has submitted a new RFC suggesting **dynamic tag names in glimmer templates**. In the transition from using inner-html semantics to using outer-html semantics in components there's one feature that has been lost: Being able to dynamically define the tag name of components.
 
 To solve this issue the RFC proposes a new `element` helper that takes a tag name and generates a contextual component that, when invoked, renders the selected element. Like this:

--- a/content/the-ember-times-issue-77.md
+++ b/content/the-ember-times-issue-77.md
@@ -33,6 +33,7 @@ Leave your thoughts on how boolean arguments could be implemented for Ember comp
 ---
 
 ## [Ember 3.6 Released 🚀](https://emberjs.com/blog/2018/12/13/ember-3-6-released.html)
+
 Ember 3.6 is out and ready to use. This release contains the last step of the **Native Class Constructor Update RFC**.  This introduces native classes in Ember but with some caveats so remember to read the [release post](https://emberjs.com/blog/2018/12/13/ember-3-6-released.html#toc_new-features-2) carefully before refactoring your code base.
 
 Ember 3.6 also contains the final stage of the **router service RFC** which includes some new methods that can improve the way you deal with routing. There’s also new deprecations and some small fixes in Ember CLI so be sure to check out the complete [release post](https://emberjs.com/blog/2018/12/13/ember-3-6-released.html).

--- a/content/the-ember-times-issue-79.md
+++ b/content/the-ember-times-issue-79.md
@@ -21,6 +21,7 @@ The new year starts off with loads of **new RFCs**! Read more about suggested **
 ---
 
 ## [Website Redesign 🎨](https://github.com/emberjs/rfcs/pull/425)
+
 The official Ember website is due for a new look and feel. That is why a [new RFC](https://github.com/wifelette/rfcs/blob/master/text/0425-website-redesign.md) proposes a **completely new look** 💅 for emberjs.com. A side effect of not having updated the look and feel of the website for some years is that for people who aren’t involved in the day-to-day of Ember development, it’s **easy to miss just how well the framework has kept up over the years**.
 
  The redesign aims to **modernize, update and improve all the things on the website** so that the impression given to the general public matches reality.

--- a/content/the-ember-times-issue-80.md
+++ b/content/the-ember-times-issue-80.md
@@ -23,11 +23,13 @@ This week you can read about the 🦄 *magical gifts* 🎁  of **DecEmber** ❄ 
 ---
 
 ## [DecEmber ❄ is over? Collect your gift! 🎁](https://airtable.com/shrm9o5W89wsAa1Tq)
+
 [DecEmber](https://www.emberjs.com/blog/2018/11/29/december-event.html) has wrapped up and it seems to have been a big hit! There were many contributions to `ember-learn` repos and it is all thanks to the awesome Ember community!
 
 Did you participate in **DecEmber**? We'd like to send you a thank you gift! Just [fill out the form](https://airtable.com/shrm9o5W89wsAa1Tq) and enjoy!
 
 ---
+
 ## [Decorators in FCP 🤓](https://github.com/emberjs/rfcs/pull/408)
 <!-- alex ignore period -->
 The [decorators Request for Comments (RFC)](https://github.com/NullVoxPopuli/rfcs/blob/decorators/text/0000-decorators.md) has been moved into **Final Comment Period (FCP)**. This means that if you have thoughts about decorators now is your chance to add your comment.

--- a/content/the-ember-times-issue-82.md
+++ b/content/the-ember-times-issue-82.md
@@ -22,6 +22,7 @@ This week you can read all about a new RFC for **accessible routing** 🗺, angl
 ---
 
 ## [New RFC: Accessible Routing in Ember 🗺](https://github.com/emberjs/rfcs/pull/433)
+
 Currently, routing in Ember is not natively accessible for users with assistive technology. This means that whenever the user navigates to a new route within an Ember application, screen readers do not read out the new content or appropriately move focus. This new RFC by [@MelSumner](https://github.com/MelSumner) proposes a solution to this so **Ember routing can be natively accessible for users with assistive technology**.
 
 Feel free to read the [RFC](https://github.com/MelSumner/rfcs/blob/MelSumner-a11y-routing/text/0000-a11y-routing.md) and leave your thoughts as a comment.
@@ -35,6 +36,7 @@ A [quest issue](https://github.com/ember-learn/guides-source/issues/139) to conv
 ---
 
 ## [Decorate Today! The Ember Way! 📍](http://ember-decorators.github.io/ember-decorators/)
+
 [Ember Decorators](https://github.com/emberjs/rfcs/blob/master/text/0408-decorators.md) are the future of using Ember along with native Javascript classes. The addon [ember-decorators](https://github.com/ember-decorators/ember-decorators) allows you to use **"The Javascript of the Future, Today!"**
 Once you install it you will have a fully RFC compliant implementation of Ember Decorators.
 The [Ember Decorators RFC](https://github.com/emberjs/rfcs/blob/master/text/0408-decorators.md) was merged into the RFC repo about two weeks ago. It will take some time until this functionality is in Ember Core.

--- a/content/the-ember-times-issue-83.md
+++ b/content/the-ember-times-issue-83.md
@@ -45,6 +45,7 @@ Finally the [Restructuring the Guides Table of Contents RFC](https://github.com/
 ---
 
 ## [Ember.js Core Team Face-to-Face 🐹](https://emberjs.com/blog/2019/01/25/framework-f2f.html)
+
 In December the **Ember.js Core Team met in-person** and remotely to review the direction that the framework API is headed, work through some architectural design questions, and figure out next steps. This resulted in [a blog post](https://emberjs.com/blog/2019/01/25/framework-f2f.html) summarizing all the cool things that were discussed. This means that you can have a look on the **Octane discussion** as well as a review of **website improvement progress**. If that sounds interesting to you, then you should check out [the blog post](https://emberjs.com/blog/2019/01/25/framework-f2f.html).
 
 ---

--- a/content/the-ember-times-issue-85.md
+++ b/content/the-ember-times-issue-85.md
@@ -26,11 +26,13 @@ In this week's issue: watch the Ember.js Documentary 🍿, check out the Ember.j
 <!--alex ignore spa-->
 JavaScript was not always the dominant force in the web. Today a lot of SPA features we see around the web were pioneered by Ember. Explore the story of why and how Ember.js came to be in [Ember.js: The Documentary](http://videos.honeypot.io/emberjs-documentary-2019/)!
 
-Here are some quick snippets from the film:
+Here are a couple of quick snippets from the film. Tom Dale said:
 
-> “JavaScript frameworks don’t have to be disposable software. Web applications don’t have to be disposable software. You don’t need to tell your manager we need to stop writing any new features for the next 6 months because it’s been 2 years and we need to rewrite – Ember is a symbol of the fact that that is a false dichotomy.” - Tom Dale
+> JavaScript frameworks don’t have to be disposable software. Web applications don’t have to be disposable software. You don’t need to tell your manager we need to stop writing any new features for the next 6 months because it’s been 2 years and we need to rewrite – Ember is a symbol of the fact that that is a false dichotomy.
 
-> “I really hope the best of Ember is ahead because I think front end engineering needs it … needs an example of something that is not trying to tell people that when something goes wrong it’s their own fault. So like something that tells you if you’re a beginner like this is for you.” - Yehuda Katz
+Yahuda Katz said:
+
+> I really hope the best of Ember is ahead because I think front end engineering needs it … needs an example of something that is not trying to tell people that when something goes wrong it’s their own fault. So like something that tells you if you’re a beginner like this is for you.
 
 Check out the [full documentary](https://www.youtube.com/watch?v=Cvz-9ccflKQ) featuring [@wycats](https://github.com/wycats), [@tomdale](https://github.com/tomdale), [@wifelette](https://github.com/wifelette), [@GavinJoyce](https://github.com/GavinJoyce), [@balinterdi](https://github.com/balinterdi), [@MelSumner](https://github.com/MelSumner), [@jessica-jordan](https://github.com/jessica-jordan) and other members of the community on [YouTube](https://www.youtube.com/watch?v=Cvz-9ccflKQ)!
 

--- a/content/the-ember-times-issue-86.md
+++ b/content/the-ember-times-issue-86.md
@@ -53,6 +53,7 @@ Read and comment on the [Decorator Support RFC](https://github.com/emberjs/rfcs/
 ---
 
 ## [Let's Fully Deprecate Partials! 🥛](https://github.com/emberjs/rfcs/pull/449)
+
 **Partials** in Ember have been around for quite some time. Today however, they are considered bad practice and all of their functionality **can be replaced** with Components. There is an [Ember Template Lint rule](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-partial.md) against their use. There was a [Pre-RFC](https://github.com/emberjs/rfcs/issues/390) created a while ago that recommended deprecating partials. Today we finally have a full RFC to [Deprecate Partials](https://github.com/emberjs/rfcs/pull/449) written up by [@GavinJoyce](https://github.com/GavinJoyce). If you want to learn more about the deprecation or maybe the alternatives to partials [check out the RFC](https://github.com/gavinjoyce/rfcs/blob/gj/deprecate-partials/text/0000-template.md). Also be sure to chime in and voice your concerns or add a 👍🎉 to the [RFC itself](https://github.com/emberjs/rfcs/pull/449).
 
 ---

--- a/content/the-ember-times-issue-87.md
+++ b/content/the-ember-times-issue-87.md
@@ -41,6 +41,7 @@ This release also contains 5 deprecations for Ember, so if you plan on upgrading
 ---
 
 ## [RFC for Single-File Components & Template Import Primitives](https://github.com/emberjs/rfcs/pull/454) 🔬
+
 [@tomdale](https://github.com/tomdale) recently opened up an RFC to explore adding single-file components and module imports in component templates!
 
 The **SFC & Template Import Primitives RFC** proposes adding experimental low-level primitives for embedding templates in JavaScript and associating templates with component classes, two highly-requested features. 🎉

--- a/content/the-ember-times-issue-89.md
+++ b/content/the-ember-times-issue-89.md
@@ -79,6 +79,7 @@ The RFC does not propose an extension to curly syntax, although a future extensi
 ---
 
 ## [Ember Data Medium Term Development Plan RFC ⚡️💾](https://github.com/emberjs/rfcs/pull/452)
+
 [@igorT](https://github.com/igorT) recently opened an RFC setting a medium term plan for Ember Data's development with the goals of increasing approachability, speed, stability, flexibility and shedding some legacy layers.
 
 The RFC describes a tactical plan to refactor Ember Data's internals to isolate `DS.Model` to facilitate swapping it out in the future, replace`InternalModel` functionality, and introduce `RecordIdentity` to uniquely identify records and harden system boundaries.

--- a/content/the-ember-times-issue-90.md
+++ b/content/the-ember-times-issue-90.md
@@ -71,6 +71,7 @@ An example: The following usages are equivalent:
 ```handlebars
 <div {{on "click" this.handleClick passive=true}}></div>
 ```
+
 ```js
 element.addEventListener('click', this.handleClick, { passive: true });
 ```

--- a/content/the-ember-times-issue-90.md
+++ b/content/the-ember-times-issue-90.md
@@ -37,6 +37,7 @@ Also The Ember Times will notify you, as soon as the full recordings of the conf
 ---
 
 ## [Coming Soon in Ember Octane](https://blog.emberjs.com/2019/02/11/coming-soon-in-ember-octane-part-1.html)
+
 If you haven't seen them already, you won't want to miss the amazing 🎉 and in-depth **blog posts** 📖 that [@pzuraq](https://github.com/pzuraq) has been putting out covering many of the new features of **Ember Octane**!
 
 It's a five part series covering Native Classes and Decorators, Angle Brackets & Named Arguments, Tracked Properties, Element Modifiers and Glimmer Components, all broken out into separate blog posts.

--- a/content/the-ember-times-issue-91.md
+++ b/content/the-ember-times-issue-91.md
@@ -70,6 +70,7 @@ Listen to the full [podcast]( https://emberweekend.com/episodes/empress-the-embe
 ---
 
 ## [Singleton Record Data RFC 💾](https://github.com/emberjs/rfcs/pull/461)
+
 Want to learn more about how some of Ember Data's APIs are developing? Take a peek at the Singleton Record Data RFC recently opened by [@runspired](https://github.com/runspired).
 
 This RFC focuses on ensuring that Record Data can be implemented as a singleton, eliminates some redundant APIs and simplifies method signatures. This plan for Record Data offers opportunities for **performance optimizations** ⚡️ and **improved feature sets**! ✨

--- a/content/the-ember-times-issue-92.md
+++ b/content/the-ember-times-issue-92.md
@@ -29,6 +29,7 @@ The **video** recordings of **EmberConf 2019** are now available! But first, rea
 [@lisaychuang](https://twitter.com/lisaychuang) shares her experience from this year’s EmberConf, and encourages newcomers in any tech community to **attend a tech conference** (and possibly **volunteer**!).
 
 As a volunteer, you can get:
+
 * A warm welcome to the community
 * Behind the scene access
 * A chill home base during the conference

--- a/content/the-ember-times-issue-94.md
+++ b/content/the-ember-times-issue-94.md
@@ -114,6 +114,7 @@ Try out [Embroider](https://github.com/embroider-build/embroider) today!
 ---
 
 ## [@action, on & fn blog post 🚀](https://www.pzuraq.com/ember-octane-update-action/)
+
 If you haven't been following the discussion on `@action`, `{{on}}`, and `{{fn}}`, this is the **blog post for you**!
 
 [@pzuraq](https://github.com/pzuraq) continues his wonderful series of blog posts with a new one that focuses on the evolution of `@action`, `{{on}}`, and `{{fn}}` in detail.

--- a/content/the-emberjs-times-issue-51.md
+++ b/content/the-emberjs-times-issue-51.md
@@ -27,6 +27,7 @@ This is what's happened in Emberland this week 🐹:
 ---
 
 ## [Back To the Future 🤖✨](https://github.com/rwjblue/ember-named-arguments-polyfill)
+
 A polyfill that is now available is [ember-named-arguments-polyfill](https://github.com/rwjblue/ember-named-arguments-polyfill) which polyfills the named arguments feature to work for Ember 2.10+.
 
 This is helpful for add-on authors who want to leverage the named arguments feature for a cleaner template. So, components receiving an argument named `foo` can now do:

--- a/content/the-road-to-ember-data-1-0.md
+++ b/content/the-road-to-ember-data-1-0.md
@@ -178,7 +178,7 @@ that work?
 Ember Data 1.0 introduces a subclass of Promise called `DataBoundPromise`. This
 object allows you to observe properties on the Promise, just as you would on a
 normal object. When the promise resolves, those properties will be updated to
-match the underlying object. If you `get `a property from a `DataBoundPromise`
+match the underlying object. If you `get` a property from a `DataBoundPromise`
 when it is unresolved, it will return `undefined`.
 
 ```js

--- a/content/this-week-in-ember-js-3.md
+++ b/content/this-week-in-ember-js-3.md
@@ -37,6 +37,7 @@ As always, check out [BREAKING_CHANGES](https://github.com/emberjs/data/blob/mas
 for information about updating your apps.
 
 ### DS.JSONSerializer
+
 In the last post we talked about the changes in the serialization API's renaming methods
 to remove the JSON specificity whilst adding hooks to manage relationship dirtiness.
 
@@ -78,6 +79,7 @@ properties on your instance. The old behavior is available via `createWithMixins
 This change should increase object creation performance by 2x.
 
 ### Other changes of note
+
 `reject` and `rejectProperty` methods have been added to `Ember.Enumerable`.
 
 `Ember.none` and `Ember.empty` have been renamed to `Ember.isEmpty` and `Ember.isNone`


### PR DESCRIPTION
## Description

Related issue: https://github.com/ember-learn/ember-blog/issues/851

I enabled 8 rules in `markdownlint`:

- MD022 (autofixed)
- MD025
- MD028
- MD030
- MD031
- MD032
- MD034
- MD038