### PR TITLE
Updated URLs to Ember Blog in the Markdown templates

### DIFF
--- a/post-templates/emberblog-template.md
+++ b/post-templates/emberblog-template.md
@@ -16,9 +16,9 @@ This release kicks off the VER+0.1 beta cycle for all sub-projects. We encourage
 You can read more about our general release process here:
 
 - [Release Dashboard](http://emberjs.com/releases/)
-- [The Ember Release Cycle](http://emberjs.com/blog/2013/09/06/new-ember-release-process.html)
-- [The Ember Project](http://emberjs.com/blog/2015/06/16/ember-project-at-2-0.html)
-- [Ember LTS Releases](http://emberjs.com/blog/2016/02/25/announcing-embers-first-lts.html)
+- [The Ember Release Cycle](https://blog.emberjs.com/new-ember-release-process/)
+- [The Ember Project](https://blog.emberjs.com/ember-project-at-2-0/)
+- [Ember LTS Releases](https://blog.emberjs.com/announcing-embers-first-lts/)
 
 ---
 

--- a/post-templates/embertimes-template.md
+++ b/post-templates/embertimes-template.md
@@ -130,7 +130,7 @@ tags:
 
   <p>Want to write for the Ember Times? Have a suggestion for next week's issue? Join us at <a href="https://discordapp.com/channels/480462759797063690/485450546887786506">#support-ember-times</a> on the <a href="https://discord.gg/emberjs">Ember Community Discord</a> or ping us <a href="https://twitter.com/embertimes">@embertimes</a> on Twitter.</p>
 
-  <p>Keep on top of what's been going on in Emberland this week by subscribing to our <a href="https://the-emberjs-times.ongoodbits.com/">e-mail newsletter</a>! You can also find our posts on the <a href="https://emberjs.com/blog/tags/newsletter.html">Ember blog</a>.</p>
+  <p>Keep on top of what's been going on in Emberland this week by subscribing to our <a href="https://the-emberjs-times.ongoodbits.com/">e-mail newsletter</a>! You can also find our posts on the <a href="https://blog.emberjs.com/tag/newsletter">Ember blog</a>.</p>
 </div>
 
 ---


### PR DESCRIPTION
## Background

We found out that old URLs that begin with `https://blog.emberjs.com/tags/` weren't being redirected to their new page correctly. The fix was made in #864.


## Description

In this PR, I updated the template Markdown files that we have so that, going forward, we use the new URLs when we create an Ember Times issue or an Ember release notes.