### PR TITLE
Fixed lint errors from alex (Part 2)

### DIFF
--- a/.alexrc
+++ b/.alexrc
@@ -2,8 +2,6 @@
   "allow": [
     "he-she",
     "her-him",
-    "just",
-    "kinks",
     "master",
     "masters",
     "obvious",

--- a/.alexrc
+++ b/.alexrc
@@ -1,15 +1,7 @@
 {
   "allow": [
-    "gal-guy",
-    "hang",
-    "harder",
     "he-she",
     "her-him",
-    "hook",
-    "hooks",
-    "host-hostess",
-    "hostesses-hosts",
-    "invalid",
     "just",
     "kinks",
     "master",

--- a/content/announcing-the-ember-security-policy.md
+++ b/content/announcing-the-ember-security-policy.md
@@ -35,7 +35,7 @@ security releases of the framework. If you're deploying Ember to
 production, you or your security team may wish to subscribe.
 
 To be clear, there are no vulnerabilities we're aware of at this time
-and there is not a security release forthcoming. We just take security
+and there is not a security release forthcoming. We take security
 extremely seriously and believe that having a procedure in place ahead of
 time will allow us to respond most effectively should the
 worst happen.

--- a/content/announcing-the-glimmer-2-alpha.md
+++ b/content/announcing-the-glimmer-2-alpha.md
@@ -13,7 +13,7 @@ tags:
 
 In this year's [EmberConf keynote](https://www.youtube.com/watch?v=OInJBwS8VDQ&list=PL4eq2DPpyBblc8aQAd516-jGMdAhEeUiW),  Yehuda mentioned that we are working on a highly optimized rendering engine for Ember called Glimmer 2.
 
-On behalf of all the contributors who have lent a hand along the way, I am very excited to announce that we have just released Ember 2.9.0-alpha.1, the first official build with Glimmer 2 included.
+On behalf of all the contributors who have lent a hand along the way, I am very excited to announce that we have released Ember 2.9.0-alpha.1, the first official build with Glimmer 2 included.
 
 ## 🔑 A Key Milestone 🔑
 
@@ -27,7 +27,7 @@ From Ember's perspective, integrating Glimmer 2 does not expose any new user-fac
 
 That being said, despite our [best efforts](https://github.com/emberjs/ember.js/issues/13127), we might not have gotten every detail right in our very first attempt, hence the alpha releases. We would really appreciate it if you could start testing your applications and report any regressions. You may refer to the [master issue](https://github.com/emberjs/ember.js/issues/13949) for a list of known issues.
 
-It is worth noting that the version number (2.9.0-alpha.1) does not imply the new engine will be automatically included in the 2.9 final release. Just like any other changes, the Glimmer 2 integration is subject to the usual rigor and stability requirements of our [release process](http://emberjs.com/blog/2013/09/06/new-ember-release-process.html). The core team will make the final decision on when to promote the feature into beta and stable releases based on our learnings from the alpha period.
+It is worth noting that the version number (2.9.0-alpha.1) does not imply the new engine will be automatically included in the 2.9 final release. Like any other changes, the Glimmer 2 integration is subject to the usual rigor and stability requirements of our [release process](http://emberjs.com/blog/2013/09/06/new-ember-release-process.html). The core team will make the final decision on when to promote the feature into beta and stable releases based on our learnings from the alpha period.
 
 Based on current information, the 2.8-LTS release (when available) will likely be the final [LTS release](http://emberjs.com/blog/2016/02/25/announcing-embers-first-lts.html) to include the current-generation rendering engine, which will be supported with critical bugfixes until at least May 2017 and security patches until at least October 2017.
 
@@ -49,7 +49,7 @@ The project originally started when Tom, Yehuda and I spiked on implementing "an
 
 While HTMLBars handled basic templating, it left the implementation of many of Ember's view layer features (notably components) up to Ember itself. Not only did it make new features more difficult to implement, it made it hard to implement them _efficiently_ out of the gate.
 
-As Ember has moved towards components and "data-down, actions-up", we wanted to do many optimizations that just weren't a good fit for the HTMLBars architecture. The lessons we learned from the spike ultimately leading us down the journey that is now known as the Glimmer 2 architecture. The underlying technologies are very interesting, but I will save those details for another time.
+As Ember has moved towards components and "data-down, actions-up", we wanted to do many optimizations that weren't a good fit for the HTMLBars architecture. The lessons we learned from the spike ultimately leading us down the journey that is now known as the Glimmer 2 architecture. The underlying technologies are very interesting, but I will save those details for another time.
 
 **As an Ember user, you can expect the new engine to unlock some long-awaited features**, such as FastBoot rehydration and a refreshed approach to components once the initial integration is complete.
 

--- a/content/another-two-oh-status-update.md
+++ b/content/another-two-oh-status-update.md
@@ -8,12 +8,12 @@ tags:
 ---
 
 
-We're just a few weeks away from the release of Ember 1.13 and Ember 2.0 beta, and while there's been a lot of focus on those releases, the trains will keep rolling on June 12. There will be a 2.1 release 6 weeks hence, and a 2.2 release 6 weeks later.
+We're a few weeks away from the release of Ember 1.13 and Ember 2.0 beta, and while there's been a lot of focus on those releases, the trains will keep rolling on June 12. There will be a 2.1 release 6 weeks hence, and a 2.2 release 6 weeks later.
 
-<!-- alex ignore easy -->
-With all of the focus on Ember 2.0, it's easy to forget that 2.0 is just a six-week release, with the added ability to remove some built-up cruft. Because of the symbolic nature of 2.0, discussions about the future have had an artificial end date of June 12, which is now just three weeks away.
+<!-- alex ignore easy just -->
+With all of the focus on Ember 2.0, it's easy to forget that 2.0 is just a six-week release, with the added ability to remove some built-up cruft. Because of the symbolic nature of 2.0, discussions about the future have had an artificial end date of June 12, which is now three weeks away.
 
-This post gives some more details about what cruft will be removed in Ember 2.0, but, since the first features in Ember 2.1 will land in Canary just three weeks hence, what we plan to do in the early releases of Ember 2.x.
+This post gives some more details about what cruft will be removed in Ember 2.0 and, since the first features in Ember 2.1 will land in three weeks, what we plan to do in the early releases of Ember 2.x.
 
 It's important to note that we've talked a lot about an improved "Ember 2 programming model" over the past several months, significantly inspired by React. While much of the model will be in place in Ember 2.0, the early releases of Ember 2.x (especially 2.1 and 2.2), will finish up some important features. This blog post details the expected timeline.
 
@@ -37,7 +37,7 @@ Some notable examples:
   `itemView`; superseded by using a component inside the loop
 * In `#with`, the `controller` option
 * The `Ember.Handlebars` namespace and all of its properties
-* `bind-attr`, superseded by just using attributes
+* `bind-attr`, superseded by using attributes
 * The legacy names `bindAttr` and `linkTo`
 * The `{{collection}}` helper
 * The `{{template}}` helper; superseded by `{{partial}}`
@@ -119,6 +119,7 @@ There are less than three weeks left until the 2.0-beta branch point, and given 
 
 **It is extremely likely to land in 2.1, or 2.2 at the latest.**
 
+<!-- alex ignore just -->
 The Routeable Component feature also includes a change that makes it possible to provide multiple asynchronous attributes to the component you are routing to, rather than just the `model` attribute. The `attrs` hook will run on every transition into the route, in contrast to the `model` hook, which doesn't run again in some cases.
 
 ## FastBoot

--- a/content/baseURL.md
+++ b/content/baseURL.md
@@ -58,7 +58,7 @@ Existing applications are able to continue using `baseURL` with a deprecation wa
 
 #### New Applications
 
-If you're starting a new application using an Ember CLI canary (or eventually 2.7 stable) everything should work correctly out of the box. We've been very careful to make sure that the out of the box experience is as smooth as possible. For the built-in development server all assets will be served at the `rootURL`. Relative URLs will continue to work just fine inside of your CSS files and paths to assets included in your templates, `index.html`, or inserted via `{{content-for}}` should specify a root-relative path.
+If you're starting a new application using an Ember CLI canary (or eventually 2.7 stable) everything should work correctly out of the box. We've been very careful to make sure that the out of the box experience is as smooth as possible. For the built-in development server all assets will be served at the `rootURL`. Relative URLs will continue to work fine inside of your CSS files and paths to assets included in your templates, `index.html`, or inserted via `{{content-for}}` should specify a root-relative path.
 
 #### Upgrading
 

--- a/content/cleaning-up-github-issues.md
+++ b/content/cleaning-up-github-issues.md
@@ -12,7 +12,7 @@ If you've been following along, the Ember issues tracker has grown to over 200 a
 
 Declaring straight-up issue bankruptcy is appealing, but does a disservice to everyone involved. There's a lot of useful information here for the core team and many of these issues are things we are actively working on solving. So we're attempting to cut down on the number of issues in a bit more targeted way.
 
-In many cases these old issues stuck around because the solution was non-trivial and only a limited set of contributors was qualified to fix them. In some instances, a fix involves considerable internal refactoring that no one has yet had time to do and was hard to justify for just one fix.
+In many cases these old issues stuck around because the solution was non-trivial and only a limited set of contributors was qualified to fix them. In some instances, a fix involves considerable internal refactoring that no one has yet had time to do and was hard to justify for one fix.
 
 To help keep things manageable, we'll be consolidating these types of issues into single meta issues. Over time we do intend to refactor and clean up different parts of the internals and knowing what bugs we need to fix while we're at it will be helpful. The original issues will be closed to help reduce overall noise, but we'll still make sure to consider them when doing our refactoring. Please continue to comment on the original issue so we can keep things organized.
 

--- a/content/compiling-templates-in-1-10-0.md
+++ b/content/compiling-templates-in-1-10-0.md
@@ -79,7 +79,7 @@ If you include the `ember.debug.js` file instead of a production file the compil
 
 ### Template Compilation Build Tools
 
-There are any number of build tool libraries that are intended to make the server side compilation of templates easier. Here are just a few (please let us know of others):
+There are any number of build tool libraries that are intended to make the server side compilation of templates easier. Here are a few (please let us know of others):
 
 * [ember-cli-htmlbars](https://github.com/rondale-sc/ember-cli-htmlbars) - Can be used either as a standalone Broccoli plugin, or as an ember-cli addon.
 * [grunt-ember-templates](https://github.com/dgeb/grunt-ember-templates) - Works as a Grunt plugin. To precompile HTMLBars templates, you must supply specific parameters to your task definition as mentioned in [this PR](https://github.com/dgeb/grunt-ember-templates/pull/77).

--- a/content/core-team-meeting-minutes-2014-01-31.md
+++ b/content/core-team-meeting-minutes-2014-01-31.md
@@ -27,9 +27,9 @@ core team member and let them know!
 
 * `ember-routing-named-substates` [#3655](https://github.com/emberjs/ember.js/pull/3655)
 
-    @krisselden: likes the feature a lot (we should “just doit”)
+    @krisselden: likes the feature a lot (we should do it)
     @wycats: naming with globals is totally unsolvable.
-    @machty: If FooLoading is ambiguous, we should just warn that global mode is not supported for this feature
+    @machty: If FooLoading is ambiguous, we should warn that global mode is not supported for this feature
     @tomdale: we need a separate task force for thinking about module mode only features.
 
     resolution: Tom and Stef will review
@@ -122,7 +122,7 @@ core team member and let them know!
 
 * [Use `QUnit.module` instead of `module`.](https://github.com/emberjs/ember.js/pull/3838)
 
-    Let's just confirm what to use as a prefix. Is `QUnit.module` OK, or should we create our own
+    Let's confirm what to use as a prefix. Is `QUnit.module` OK, or should we create our own
     (perhaps `EmberDev.module` or something)?
 
     resolution: "Go"

--- a/content/core-team-meeting-minutes-2014-02-07.md
+++ b/content/core-team-meeting-minutes-2014-02-07.md
@@ -94,7 +94,7 @@ The core team reviewed the following pull requests for already enabled in canary
 
 #### Feature Process
 
-We reviewed the a proposed change to the process for adding features. This isn't a major departure, just an iteration
+We reviewed the a proposed change to the process for adding features. This isn't a major departure, but an iteration
 on what we are currently doing:
 
 Process:

--- a/content/core-team-meeting-minutes-2014-02-21.md
+++ b/content/core-team-meeting-minutes-2014-02-21.md
@@ -68,7 +68,7 @@ the 1.6.x beta series:
     @stefanpenner and @machty met in person on Tuesday to discuss an API that supported
     lazy loading of routes and will continue the conversation as these changes are made.
 
-    Resolution: Not ready just yet. We don’t  want to serialize default values into the
+    Resolution: Not ready yet. We don’t  want to serialize default values into the
     URL. False params should be represented as “=false”, rather than merely being absent
     from URL (which was ambiguous). So, this example JSBin from the docs is wrong:
     [http://emberjs.jsbin.com/ucanam/2708](http://emberjs.jsbin.com/ucanam/2708).

--- a/content/core-team-meeting-minutes-2014-03-07.md
+++ b/content/core-team-meeting-minutes-2014-03-07.md
@@ -156,5 +156,5 @@ core team member and let them know!
     > exists within Handlebars, but is not exposed to `Ember.Handlebars.precompile`.
     > As such, I think that we should likely re-evaluate the prior decision.
 
-    Resolution. Ship it. This just passes from Handlebars to Ember.Handlebars
+    Resolution. Ship it. This passes from Handlebars to Ember.Handlebars
 

--- a/content/core-team-meeting-minutes-2014-04-04.md
+++ b/content/core-team-meeting-minutes-2014-04-04.md
@@ -121,7 +121,7 @@ core team member and let them know!
   **Resolution**
 
    It is possible to transition to a globbing route, but like any target route with a dynamic segment, you need to
-   provide a object / param, which in this case can just be a string of the path you want to use for that globbed segment:
+   provide a object / param, which in this case can be a string of the path you want to use for that globbed segment:
 
    `this.transitionTo('yargle', "MY/COOL/URL");`
 

--- a/content/core-team-meeting-minutes-2014-06-13.md
+++ b/content/core-team-meeting-minutes-2014-06-13.md
@@ -46,5 +46,5 @@ for usage details.
 ### Keeping the train moving
 
 In the last meeting we discussed why the release of 1.6 and 1.7.beta was delayed.
-In this meeting we resolved to not delay releases just because we hope to include
+In this meeting we resolved to not delay releases, because we hope to include
 a specific feature.

--- a/content/core-team-meeting-minutes-2014-08-01.md
+++ b/content/core-team-meeting-minutes-2014-08-01.md
@@ -46,7 +46,7 @@ core team member and let them know!
 
 We're starting work to revamp
 our [Getting Started Guide](http://emberjs.com/guides/getting-started/).
-TodoMVC is just too small of an app to demonstrate enough topics. We were
+TodoMVC is too small of an app to demonstrate enough topics. We were
 holding off in hopes that there would be further progress on the [successor
 to TodoMVC](https://github.com/tastejs/TasteApp) but this project has stalled.
 

--- a/content/countdown-to-the-new-year-ember-mapbox-gl.md
+++ b/content/countdown-to-the-new-year-ember-mapbox-gl.md
@@ -179,6 +179,7 @@ Much of ember-mapbox-gl is simply a _bindings_ layer. It provides a declarative 
 
 ### Note on map data providers
 
+<!-- alex ignore host-hostess -->
 I'm a little disappointed by the dearth of free and open _vector_ map data providers. That said, if you find that you would like to host your own map tile provider, check out [OpenMapTiles](https://openmaptiles.org/). It's a free and open source server that hosts those tile URLs we were using at the beginning. My team uses it and have had no issues.
 
 Thanks for reading! If you have any questions, please message me via the [Ember Discord](https://discord.gg/emberjs) chat (Matt Gardner#6278).

--- a/content/ember-1-0-prerelease.html.md
+++ b/content/ember-1-0-prerelease.html.md
@@ -36,8 +36,8 @@ Ember 1.0 Prerelease includes what we think is the most advanced tool
 for modeling your application's state: `Ember.Router`. The router allows
 you to describe the state of your application as discrete objects, which
 means it's impossible for your application to ever get into a "bad
-state." And because the URL is just a serialization of your
-application's state, you just tell us how to build the URL and we'll
+state." And because the URL is a serialization of your
+application's state, you tell us how to build the URL and we'll
 keep it up-to-date as your users move throughout the application.
 
 <!-- alex ignore easy -->

--- a/content/ember-1-0-rc.html.md
+++ b/content/ember-1-0-rc.html.md
@@ -31,7 +31,7 @@ router.transitionTo('index');
 router.replaceWith('index');
 ```
 
-In the `redirect` hook, you can just use `replaceWith` and Ember won't create
+In the `redirect` hook, you can use `replaceWith` and Ember won't create
 a history entry.
 
 In a controller, you can use `replaceRoute` (instead of `transitionToRoute`)

--- a/content/ember-1-0-rc5.md
+++ b/content/ember-1-0-rc5.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-Ember.js 1.0 RC5 has just been released and is now available from the
+Ember.js 1.0 RC5 has been released and is now available from the
 main website as well as [builds.emberjs.com](http://builds.emberjs.com).
 
 RC5 fixes several regressions and bugs found in RC4. Notably:

--- a/content/ember-1-0-rc5.md
+++ b/content/ember-1-0-rc5.md
@@ -15,6 +15,7 @@ main website as well as [builds.emberjs.com](http://builds.emberjs.com).
 
 RC5 fixes several regressions and bugs found in RC4. Notably:
 
+<!-- alex disable hang -->
 * A performance regression caused by a change to run loop scheduling has
   been fixed. Thanks to [Erik Bryn](https://twitter.com/ebryn) for
   working on this.
@@ -23,6 +24,7 @@ RC5 fixes several regressions and bugs found in RC4. Notably:
 * The `ember-testing` package, which contains additional helpers for
   testing Ember.js apps, is no longer included in the production build.
   This means less JavaScript for end users to load over the network.
+<!-- alex enable hang -->
 
 Thank you to everyone who filed issues and pull requests. Please try out
 RC5 in your applications and report any issues or regressions you find

--- a/content/ember-1-0-rc7.md
+++ b/content/ember-1-0-rc7.md
@@ -41,4 +41,4 @@ Ember’s old router was deprecated prior to the first RC and while it’s never
 
 * Added functionality to Router.map to allow it to be called multiple times without the map being overwritten. Allows routes to be added at runtime.
 
-_UPDATE:_ The post previously recommended the use of `Route#generateController` for cases where the controller was not associated with a route. We are now directing users to just explicitly declare the controller's class instead of relying on generation.
+_UPDATE:_ The post previously recommended the use of `Route#generateController` for cases where the controller was not associated with a route. We are now directing users to explicitly declare the controller's class instead of relying on generation.

--- a/content/ember-1-10-0-released.md
+++ b/content/ember-1-10-0-released.md
@@ -12,7 +12,7 @@ tags:
 
 We are pleased to announce the release of both Ember.js 1.10.0 and the
 first beta in the 1.11 series. This comes as the tenth cycle of our
-release process that began just after 1.0 was released.
+release process that began after 1.0 was released.
 
 The 1.10 release represents the effort of at least 50 contributors
 across over 553 commits.

--- a/content/ember-1-11-0-released.md
+++ b/content/ember-1-11-0-released.md
@@ -12,7 +12,7 @@ tags:
 
 We are pleased to announce the release of both Ember.js 1.11.0 and the
 first beta in the 1.12 series. This comes as the eleventh cycle of our
-release process that began just after 1.0 was released.
+release process that began after 1.0 was released.
 
 The 1.11 release represents the effort of at least 87 contributors
 across over 646 commits.
@@ -109,7 +109,7 @@ bound `style` attributes will warn when the value is not marked safe.
 ```
 
 The examples that follow are intended to demonstrate how this
-works in practice. For example these bindings Just Work:
+works in practice.
 
 ```handlebars
 {{! Works as expected }}

--- a/content/ember-1-11-1-released.md
+++ b/content/ember-1-11-1-released.md
@@ -22,6 +22,7 @@ HTMLBars' attribute helpers instead of jQuery's.
 Unfortunately, this work lead to an error when `CollectionView` instances were used with
 `attributeBindings` specified.  This regression is fixed in 1.11.1.
 
+<!-- alex ignore invalid -->
 ### Invalid URLs
 
 Refactoring in the router initialization process lead to a bug that caused the browsers URL
@@ -42,7 +43,7 @@ regression was first introduced in 1.11.0-beta.4.
 
 ### Incorrect Assertion for {{each foos itemControler='bar'}}
 
-During the 1.11.0 cycle an issue regarding `{{each}}` with prototype extensions disabled was reported.
+During the 1.11.0 cycle, an issue was reported regarding `{{each}}` when prototype extensions were turned off.
 The solution to that issue was to add a much more helpful assertion when an `ArrayController`'s model
 did not have `Ember.Array` mixed into it. Unfortunately, this assertion also was triggered when the
 model was simply `undefined`. The assertion has been updated to ignore falsey `model`'s in 1.11.1.

--- a/content/ember-1-11-1-released.md
+++ b/content/ember-1-11-1-released.md
@@ -53,7 +53,7 @@ model was simply `undefined`. The assertion has been updated to ignore falsey `m
 
 In 1.11.0 using the `{{render}}` helper (i.e. `{{render 'post'}}`) when a `PostView` is present would not
 provide the view with a template (it was assumed to be manually specified in the view via `templateName`
-property). As of 1.11.1 you can specify the `templateName` in the `{{render}}` helpers view (just like in 1.11.0),
+property). As of 1.11.1 you can specify the `templateName` in the `{{render}}` helpers view (similarly to in 1.11.0),
 but if you do not the views template will be defaulted to a template with the same name as the view itself.
 
 ## Changelogs

--- a/content/ember-1-12-released.md
+++ b/content/ember-1-12-released.md
@@ -205,8 +205,9 @@ Ember 1.13 is:
 * the last minor release in the 1.x series
 * the first release that includes the new **Glimmer rendering engine**
 
-Just to recap; what is Glimmer?
+To recap; what is Glimmer?
 
+<!-- alex disable just -->
 * A new faster rendering engine that is especially fast at updates.
 * An implementation of the React-inspired "just re-render it" programming model
   for components, with one-way data flow by default and better enforcement for
@@ -214,6 +215,7 @@ Just to recap; what is Glimmer?
 * Supports angle-bracket components (`<my-component />`), ergonomic attributes
   (`<my-link href="{{url}}.html">go home</my-link>`), that hews closely to HTML
   syntax with a few small enhancements.
+<!-- alex enable just -->
 
 We'll be writing a blog post that expands on the programming model of Ember 2.0
 and talks about the most important new features in the next few days, and full

--- a/content/ember-1-13-0-released.md
+++ b/content/ember-1-13-0-released.md
@@ -13,7 +13,7 @@ tags:
 
 We are pleased to announce the release of both Ember.js 1.13.0 and the
 first beta in the 2.0 series. This comes as the thirteenth cycle of our
-release process that began just after 1.0 was released.
+release process that began after 1.0 was released.
 
 The 1.13 release represents the effort of at least 43 contributors
 across over 680 commits.
@@ -52,6 +52,7 @@ Previous iterations of Ember's rendering engine **relied** on granular observati
 
 While this was reasonably efficient in cases where the developer could use `set` (and the array equivalents) to mutate values, it had two related issues:
 
+<!-- alex disable just -->
 - This forced developers to represent all changes in terms of granular
   observers. In many cases this could be extremely awkward. This was
   especially problematic when working with Arrays, since (for example)
@@ -62,6 +63,7 @@ While this was reasonably efficient in cases where the developer could use `set`
   natural way to represent the change. This meant that while it was
   usually possible in theory to "just re-render" a component, it was,
   in practice, cost prohibitive (to say the least).
+<!-- alex enable just -->
 
 To address these issues, Glimmer adopts a value-diffing strategy, using a virtual tree of the dynamic areas of the DOM. This means that even if the original data structure (for example, an array) is completely replaced, the DOM is not updated unless the resulting rendered content has changed.
 
@@ -139,7 +141,7 @@ a return value (since the return value of an action handler controlled further
 bubbling).
 
 Ember 2.x is component-driven, and replaces action bubbling with a function-passing
-solution. This greatly simplifies working with actions (they are just functions),
+solution. This greatly simplifies working with actions (they are functions, after all),
 enables return values, and introduces some powerful new currying capabilities.
 
 For example, action `submit` is passed to `my-component` where it is called upon
@@ -180,7 +182,7 @@ Actions:
 - Return a value. For example `var result = this.attrs.submit();`
 - Can curry. For example `submit=(action 'setName' 'Sal')` would pass `"Sal"` as
   the first argument to `setName` when `submit` is called. Actions can curry
-  multiple times, adding arguments at each scope. For example `submit=(action attrs.actionPassedIn someProp)` just adds an argument to any already curried onto `actionPassedIn`.
+  multiple times, adding arguments at each scope. For example `submit=(action attrs.actionPassedIn someProp)` adds an argument to any already curried onto `actionPassedIn`.
 
 Additionally the `action` helper has two options:
 

--- a/content/ember-1-2-0-and-ember-1-3-0-beta-released.md
+++ b/content/ember-1-2-0-and-ember-1-3-0-beta-released.md
@@ -12,7 +12,7 @@ tags:
 What better way to celebrate the holiday season than with two
 brand-spankin' new releases of Ember.js?
 
-Hot off the presses, we've got 1.2.0 and 1.3.0 beta on deck just for
+Hot off the presses, we've got 1.2.0 and 1.3.0 beta on deck for
 you. Since we started following a [Chrome-like release
 cycle](/blog/2013/09/06/new-ember-release-process.html), we'll have two
 new releases for you every six weeks. 1.2.0 is the newest stable

--- a/content/ember-1-3-0-and-ember-1-4-0-beta-released.md
+++ b/content/ember-1-3-0-and-ember-1-4-0-beta-released.md
@@ -11,8 +11,8 @@ tags:
 
 
 We are pleased to announce that both Ember.js 1.3.0 and the first beta in the 1.4 series
-have just been released. This comes as the third cycle of our six-week release
-process that began just after 1.0 was released.
+have been released. This comes as the third cycle of our six-week release
+process that began after 1.0 was released.
 
 ### New in 1.3
 

--- a/content/ember-1-4-0-and-ember-1-5-0-beta-released.md
+++ b/content/ember-1-4-0-and-ember-1-5-0-beta-released.md
@@ -11,8 +11,8 @@ tags:
 
 
 We are pleased to announce that both Ember.js 1.4.0 and the first beta in the 1.5 series
-have just been released. This comes as the fourth cycle of our six-week release
-process that began just after 1.0 was released.
+have been released. This comes as the fourth cycle of our six-week release
+process that began after 1.0 was released.
 
 ### New features in 1.4
 
@@ -118,6 +118,7 @@ Then from the template:
 {{input autofocus=omgAutofocusMe}}
 ```
 
+<!-- alex ignore just -->
 This certainly is not ideal, and causes many issues for people that expect it to "just work".
 
 Thankfully, this has gotten MUCH better with the 1.4 release. In 1.4 any attribute bindings that do not

--- a/content/ember-1-5-0-and-ember-1-6-beta-released.md
+++ b/content/ember-1-5-0-and-ember-1-6-beta-released.md
@@ -11,8 +11,8 @@ tags:
 
 
 We are pleased to announce that both Ember.js 1.5.0 and the first beta in the 1.6 series
-have just been released. This comes as the fifth cycle of our six-week release
-process that began just after 1.0 was released.
+have been released. This comes as the fifth cycle of our six-week release
+process that began after 1.0 was released.
 
 ### New features in 1.5
 

--- a/content/ember-1-6-0-and-ember-1-7-0-beta-released.md
+++ b/content/ember-1-6-0-and-ember-1-7-0-beta-released.md
@@ -11,8 +11,7 @@ tags:
 
 
 We are pleased to announce that both Ember.js 1.6.0 and the first beta in the 1.7 series
-have just been released. This comes as the sixth cycle of our release process that began
-just after 1.0 was released.
+have been released. This comes as the sixth cycle of our release process that began after 1.0 was released.
 
 ### Delays Detailed
 
@@ -23,7 +22,7 @@ loading the transpiled modules. Unfortunately, adding the additional loader over
 boot has a fairly significant performance impact on boot speed of older mobile clients
 (approximately 5-10% boot time penalty).
 
-This regression was brought to our attention just before 1.6.0 was intended to ship (late
+This regression was brought to our attention before 1.6.0 was intended to ship (late
 May), and we decided to hold the release until a fix could be applied. In retrospect this
 was absolutely the wrong decision. The fix has taken much longer than originally anticipated
 and in the meantime folks are stuck with 1.5.1. Many of our users either are not affected

--- a/content/ember-1-7-0-released.md
+++ b/content/ember-1-7-0-released.md
@@ -11,8 +11,7 @@ tags:
 
 
 We are pleased to announce that both Ember.js 1.7.0 and the first beta in the 1.8 series
-have been released. This comes as the seventh cycle of our release process that began just
-after 1.0 was released.
+have been released. This comes as the seventh cycle of our release process that began after 1.0 was released.
 
 This release brings bug fixes, potentially breaking changes and new features.
 

--- a/content/ember-1-8-0-released.md
+++ b/content/ember-1-8-0-released.md
@@ -12,7 +12,7 @@ tags:
 
 We are pleased to announce that both Ember.js 1.8.0 and the first beta in the
 1.9 series have been released. This comes as the eighth cycle of our release
-process that began just after 1.0 was released.
+process that began after 1.0 was released.
 
 This release represents the effort of at least 40 contributors across over 600 commits.
 

--- a/content/ember-1-9-0-released.md
+++ b/content/ember-1-9-0-released.md
@@ -12,7 +12,7 @@ tags:
 
 We are pleased to announce the release of both Ember.js 1.9.0 and the
 first beta in the 1.10 series. This comes as the ninth cycle of our
-release process that began just after 1.0 was released.
+release process that began after 1.0 was released.
 
 The 1.9 release represents the effort of at least 52 contributors across over 436 commits.
 

--- a/content/ember-2-10-released.md
+++ b/content/ember-2-10-released.md
@@ -183,6 +183,7 @@ to specify the HTTP method or
 provide custom HTTP headers per request. This feature has been available
 in beta builds since the 2.8 beta cycle.
 
+<!-- alex ignore invalid -->
 Unfortunately, this feature slipped into the code base without going
 though a proper RFC process. Despite being enabled in the beta channel
 for a while now, we decided that it should be disabled again in favour

--- a/content/ember-2-14-released.md
+++ b/content/ember-2-14-released.md
@@ -210,7 +210,7 @@ Majority of the changes in this release happened under the hood to improve docum
 
 #### NPM 5 and Node 8 support
 
-Ember CLI now supports Node 8 and npm 5 out of the box, make sure to try it out! Some developers reported issues with `node@8.1.0` where Ember CLI would hang indefinitely. After upgrading to version `node@8.1.2`+ this issue no longer appeared.
+Ember CLI now supports Node 8 and npm 5 out of the box, make sure to try it out! Some developers reported issues with `node@8.1.0` where Ember CLI would be unresponsive. After upgrading to version `node@8.1.2`+ this issue no longer appeared.
 
 #### Specifying a blueprint for a new app
 

--- a/content/ember-2-18-released.md
+++ b/content/ember-2-18-released.md
@@ -218,10 +218,9 @@ Previously, if you were npm-linking an addon that had itself npm-linked a depend
 
 #### `crossdomain.xml` removed for new applications
 
+<!-- alex ignore hostesses-hosts -->
 `crossdomain.xml` was originally introduced to limit vulnerabilities when
-using the Flash Player.
-It did this by declaring which hosts the Flash Player could connect to outside
-the one hosting the file.
+using the Flash Player. It did this by declaring which hosts the Flash Player could connect to outside the one hosting the file.
 Browsers have since disabled Flash for security reasons, rendering the file moot.
 Ember CLI 2.18 will no longer generate the file for new applications.
 

--- a/content/ember-2-8-and-2-9-beta-released.md
+++ b/content/ember-2-8-and-2-9-beta-released.md
@@ -272,7 +272,7 @@ did it make new features more difficult to implement, it made it hard to
 implement them _efficiently_ out of the gate.
 
 As Ember has moved towards components and "data-down, actions-up", we wanted to
-do many optimizations that just weren't a good fit for the HTMLBars
+do many optimizations that weren't a good fit for the HTMLBars
 architecture. The lessons we learned from the spike ultimately leading us down
 the journey that is now known as the Glimmer 2 architecture. The underlying
 technologies are very interesting, but I will save those details for another

--- a/content/ember-2018-roadmap-call-for-posts.md
+++ b/content/ember-2018-roadmap-call-for-posts.md
@@ -35,7 +35,7 @@ Your post can be on any online writing platform, but we suggest:
 
 ### Topic Ideas
 
-We'd like to hear about any aspect of Ember you have hopes for in 2018--not just about the Ember.js framework. Please include your desires for Ember Data, Ember CLI, tooling, the community, addons, and anything else Ember-related.
+We'd like to hear about any aspect of Ember you have hopes for in 2018--not only about the Ember.js framework. Please include your desires for Ember Data, Ember CLI, tooling, the community, addons, and anything else Ember-related.
 
 Here are some broad ideas that might help you get started:
 

--- a/content/ember-2019-roadmap-call-for-posts.md
+++ b/content/ember-2019-roadmap-call-for-posts.md
@@ -36,7 +36,7 @@ Your post can be on any online writing platform, but we suggest:
 
 ### _Topic ideas_
 
-We'd like to hear about any aspect of Ember you have hopes for in 2019--not just about the Ember.js framework. Please include your desires for Ember Data, Ember CLI, learning, tooling, the community, addons, and anything else Ember-related.
+We'd like to hear about any aspect of Ember you have hopes for in 2019--not only about the Ember.js framework. Please include your desires for Ember Data, Ember CLI, learning, tooling, the community, addons, and anything else Ember-related.
 
 Here are some broad ideas that might help you get started:
 

--- a/content/ember-3-1-beta-released.md
+++ b/content/ember-3-1-beta-released.md
@@ -147,7 +147,7 @@ system.
 
 Ember applications have long created a wrapping `div` around their rendered
 content: `<div class="ember-view">`. With ember-optional-features, this
-functionality can now be disabled:
+functionality can now be turned off:
 
 ```bash
 ember feature:disable application-template-wrapper
@@ -250,8 +250,8 @@ However, enabling this feature will prompt you to optionally run a codemod
 which creates backing classes for all template-only components, meaning
 both the implicit `div` and backing class are retained.
 
-Although enabling this feature will eventually be the default for Ember, leaving
-the feature disabled is not deprecated in this release. You can read more
+<!-- alex ignore invalid -->
+Although enabling this feature will eventually be the default for Ember, leaving the feature disabled is not deprecated in this release. You can read more
 details about this optional feature and the motivations for introducing it in
 [RFC #278](https://github.com/emberjs/rfcs/blob/master/text/0278-template-only-components.md).
 

--- a/content/ember-3-1-released.md
+++ b/content/ember-3-1-released.md
@@ -120,7 +120,7 @@ Thanks to [Godfrey Chan](https://twitter.com/chancancode) and [Robert Jackson](h
 
 ##### New Optional Feature: Application Template Wrapper
 
-Ember applications have long created a wrapping `div` around their rendered content: `<div class="ember-view">`. With ember-optional-features, this functionality can now be disabled:
+Ember applications have long created a wrapping `div` around their rendered content: `<div class="ember-view">`. With ember-optional-features, this functionality can now be turned off:
 
 ```bash
 ember feature:disable application-template-wrapper
@@ -198,6 +198,7 @@ Enabling this feature may require changes to your application's CSS, or to any o
 
 However, enabling this feature will prompt you to optionally run a codemod which creates backing classes for all template-only components, meaning both the implicit `div` and backing class are retained.
 
+<!-- alex ignore invalid -->
 Although enabling this feature will eventually be the default for Ember, leaving the feature disabled is not deprecated in this release. You can read more details about this optional feature and the motivations for introducing it in [RFC #278](https://github.com/emberjs/rfcs/blob/master/text/0278-template-only-components.md).
 
 #### Positional Params Bug Fix (4 of 4)

--- a/content/ember-3-11-released.md
+++ b/content/ember-3-11-released.md
@@ -119,7 +119,7 @@ Current count: {{this.count}}
 <button {{on "click" this.countUp passive=true}}>Add One</button>
 ```
 
-The `{{on}}` modifier in this example attaches a passive "click" event listener on the button, such that when the button is clicked, the `countUp` action will be called. Just as before, wrapping our function in an `action` call ensures the `countUp` action will have the right `this` value at runtime.
+The `{{on}}` modifier in this example attaches a passive "click" event listener on the button, such that when the button is clicked, the `countUp` action will be called. Like before, wrapping our function in an `action` call ensures the `countUp` action will have the right `this` value at runtime.
 
 By default, the action passed to the `{{on}}` modifier will receive the DOM event as an argument. The `fn` helper can be used in conjunction with the `{{on}}` modifier to alter this behavior. Along with the "Splattributes" feature mentioned above, the `{{on}}` modifier can also be applied to component elements as well.
 

--- a/content/ember-3-3-released.md
+++ b/content/ember-3-3-released.md
@@ -67,7 +67,7 @@ Ember Data is the official data persistence library for Ember.js applications.
 
 ### Changes in Ember Data 3.3
 
-Since Ember Data 3.2 was just released two weeks ago we did not feel confident that the changes in the beta branch had received enough
+Since Ember Data 3.2 was released two weeks ago we did not feel confident that the changes in the beta branch had received enough
 testing. As a result, we have decided to re-release Ember Data 3.2 as Ember Data 3.3 to maintain the release train cadence. Ember Data
 3.3.0-beta.1 will be released again as 3.4.0-beta.1 so it can continue to be evaluated for a full beta cycle.
 

--- a/content/ember-3-4-released.md
+++ b/content/ember-3-4-released.md
@@ -128,7 +128,7 @@ export default setComponentManager('basic', EmberObject.extend({
 }));
 ```
 
-Finally, users of the `ember-basic-component` addon in this example, will be able to reuse and extend that component just like any other classic component:
+Finally, users of the `ember-basic-component` addon in this example, will be able to reuse and extend that component like any other classic component:
 
 ```javascript
 // an-addon-users-app/app/components/foo-bar-custom.js

--- a/content/ember-accessibility-and-a11y-tools.md
+++ b/content/ember-accessibility-and-a11y-tools.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-What is it like to build an accessible Ember app? With just a few lines of code, you can audit your app for problems, get customized advice on how to fix them, and see visual indications of which things on a page need work. We'll walk through an example using the [Super Rentals](https://github.com/ember-learn/super-rentals) app from Ember's [official tutorials](https://guides.emberjs.com/current/tutorial/ember-cli/). We'll also cover some improvements being made to Ember itself for a better experience out of the box.
+What is it like to build an accessible Ember app? With a few lines of code, you can audit your app for problems, get customized advice on how to fix them, and see visual indications of which things on a page need work. We'll walk through an example using the [Super Rentals](https://github.com/ember-learn/super-rentals) app from Ember's [official tutorials](https://guides.emberjs.com/current/tutorial/ember-cli/). We'll also cover some improvements being made to Ember itself for a better experience out of the box.
 
 An [accessible app](https://en.wikipedia.org/wiki/Web_accessibility) is one that gives all users equal access to information and functionality, including those who use Assistive Technology like screen readers. This kind of work is sometimes abbreviated as `a11y`. There are set standards called the [Web Content Accessibility Guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/), and in many cases, [it's the law](https://www.w3.org/WAI/Policy/).
 
@@ -69,7 +69,7 @@ It's important to incorporate the check into the test suite, because in larger a
 
 ### Run the test suite
 
-Start up your app with `ember serve` and then navigate to [http://localhost:4200/tests](http://localhost:4200/tests) to see the browser-based test runner. Sure enough, we see some problems! Just like we saw in the console earlier, there are specific error messages and links to resources that help us to fix the problems.
+Start up your app with `ember serve` and then navigate to [http://localhost:4200/tests](http://localhost:4200/tests) to see the browser-based test runner. Sure enough, we see some problems! Like we saw in the console earlier, there are specific error messages and links to resources that help us to fix the problems.
 
 ![Errors in the tests route](/images/blog/2018-06-17-ember-accessibility-and-a11y-tools/route-test-errors.png)
 
@@ -105,7 +105,7 @@ Fixing issues with contrast, aria labels, and DOM elements is an important step 
 
 ## Using ember-a11y-landmarks for roles
 
-Here's just one example of an addon that helps reduce the number of changes to make by hand. The [ember-a11y-landmarks](https://github.com/ember-a11y/ember-a11y-landmarks) addon helps manage the roles that should go on semantic tags like `<header>` and `<nav>`, without needing to learn the intricacies of when to use them.
+Here's one example of an addon that helps reduce the number of changes to make by hand. The [ember-a11y-landmarks](https://github.com/ember-a11y/ember-a11y-landmarks) addon helps manage the roles that should go on semantic tags like `<header>` and `<nav>`, without needing to learn the intricacies of when to use them.
 
 One huge thing you can do to improve an app's accessibility is to use semantic tags in the HTML. For example, always use `<button>` for buttons, instead of making them `divs`. However, some semantic tags still need extra attributes called roles for screen readers to work right, and they only need them some of the time based on their position in the DOM. ember-a11y-landmarks to the rescue!
 
@@ -154,7 +154,7 @@ Install it and replace instances of `{{outlet}}` with
 
 So why is this necessary? If you're looking at a decently accessible website and you hit the tab key, you'll see the focus jump between different elements - things get highlighted. Front end frameworks like Ember sometimes get in the way of the DOM structure that works best for screen reader focus, since as you move between routes, only part of the page changes. The contents of `{{outlet}}` are dynamic.
 
-The problem is that screen readers rely heavily on what has focus. Imagine if you had to start reading at the very top of the page whenever a route in your app changed, instead of just reading the content that is new, or if you weren't able to tell that some content had changed! ember-a11y corrects for that focus problem so that Assistive Technology navigation using focus works correctly. From the README:
+The problem is that screen readers rely heavily on what has focus. Imagine if you had to start reading at the very top of the page whenever a route in your app changed, instead of reading the content that is new, or if you weren't able to tell that some content had changed! ember-a11y corrects for that focus problem so that Assistive Technology navigation using focus works correctly. From the README:
 
 > The current implementation of this addon will immediately apply focus to the most relevant piece of content based on actions users take (clicking buttons, links, etc). This allows screen readers to catch changes and read the right information, thus providing a much better experience for screen reader users.
 

--- a/content/ember-data-1-0-beta-12-released.md
+++ b/content/ember-data-1-0-beta-12-released.md
@@ -36,7 +36,7 @@ been fetched in the store. Sometimes, this is not desirable. For example, you
 may not know if you have already loaded the post in another request via
 sideloading, or you want the most up to date information. You could either
 check if the record existed using
-[store.hasRecordForId][store-has-record-for-id], or just always call
+[store.hasRecordForId][store-has-record-for-id], or always call
 [reload][model-reload] on your model in the route's `afterModel`hook.
 
 `store.fetch` wraps this common pattern by reloading a record if it exists in
@@ -106,7 +106,7 @@ var Post = DS.Model.extend({
 });
 ```
 
-**no longer works**. Instead, you should just watch each attribute like you
+**no longer works**. Instead, you should watch each attribute like you
 would with any `Ember.Object`:
 
 ```javascript

--- a/content/ember-data-1-0-beta-19-released.md
+++ b/content/ember-data-1-0-beta-19-released.md
@@ -19,7 +19,7 @@ Thank you for helping us push toward a stable release of Ember Data!
 
 `changedAttributes`, which represents the changes that have happened
 since the model was last synced with the server, are now available on
-the snapshot in your adapters and serializers, instead of just on
+the snapshot in your adapters and serializers, instead of on
 `DS.Model` instances.
 
 ## Breaking Changes

--- a/content/ember-data-1-13-released.md
+++ b/content/ember-data-1-13-released.md
@@ -606,7 +606,7 @@ handleResponse: function(status, headers, payload) {
 ```
 
 You could also subclass two helper methods, `isInvalid` and `isSuccess`
-to customize when you adapter considers a request succesful or invalid.
+to customize when you adapter considers a request succesful or not valid.
 
 Default implementation of `isInvalid` returns
 true if http status code is `422`, however, you may desire other

--- a/content/ember-data-1-13-released.md
+++ b/content/ember-data-1-13-released.md
@@ -269,7 +269,7 @@ While `store.findRecord` and `store.findAll` now have sensible caching defaults
 and are easy to override in specific places in the app, oftentimes your app and
 adapter layer have specific knowledge related to caching. For example, your backend
 might have given you an `expires` header, or you may not want to try fetching background updates if the network is down. To support these use cases, we have added new adapter
-hooks to customize caching app wide beyond just passing options to `findRecord` and `findAll`.
+hooks to customize caching app wide beyond passing options to `findRecord` and `findAll`.
 
 Now, whenever you call `findRecord` or `findAll`, and the record is already cached in the store, the store will ask the adapter whether it needs to immediately reload it, or if it needs to update it in the background.
 
@@ -400,7 +400,7 @@ store.push({
 
 This allows for much better and fine grained meta handling, and ensures we do
 not have to support, maintain and document a completely custom JSON format
-as we had to until now, but can just reference the [JSON API specification](http://jsonapi.org/).
+as we had to until now, but can reference the [JSON API specification](http://jsonapi.org/).
 
 We will be publishing an [ember-watson](https://github.com/abuiles/ember-watson) helper that will be rewriting all the uses
 of `store.push` inside your tests to the new format, as well as addon with helpers
@@ -431,12 +431,12 @@ from `extract` hooks but also doing `store.push` with other data was both confus
 hard to debug and optimize and also prevented us from implementing proper metadata support, especially for sideloaded arrays and records.
 
 In Ember Data 1.13 this process has been greatly simplified. **In 1.13 Serializers
-should just make the whole payload conform to the JSON API spec, and return the whole payload**. They should no longer `store.push` themselves.
+should make the whole payload conform to the JSON API spec, and return the whole payload**. They should no longer `store.push` themselves.
 
 In order to be backwards compatible, we created a new hook `normalizeResponse` which
-Serializers should now implement, and just return JSON API from that hook.
+Serializers should now implement and return JSON API from that hook.
 
-For example a Serializer responsible for normalizing the above sample payload would just transform it to:
+For example a Serializer responsible for normalizing the above sample payload would transform the payload to:
 
 ```javascript
 {

--- a/content/ember-data-2-5-released.md
+++ b/content/ember-data-2-5-released.md
@@ -170,10 +170,7 @@ For instance, if a user has many pets, which is a polymorphic relationship, the 
 }
 ```
 
-This is particularly useful for polymorphic relationships not backed
-  by [STI](https://en.wikipedia.org/wiki/Single_Table_Inheritance)
-  when just including the id of the records is not enough.
-
+This is particularly useful for polymorphic relationships not backed by [STI](https://en.wikipedia.org/wiki/Single_Table_Inheritance) when including the id of the records is not enough.
 
 For more details on changes in the 2.6 beta, please review the
 [Ember Data 2.6.0-beta.1 CHANGELOG](https://github.com/emberjs/data/blob/v2.6.0-beta.1/CHANGELOG.md).

--- a/content/ember-data-progress-update.md
+++ b/content/ember-data-progress-update.md
@@ -10,7 +10,7 @@ tags:
 ---
 
 
-Just over a month ago, we told you about our [plans for stabilizing Ember
+A month ago, we told you about our [plans for stabilizing Ember
 Data](/blog/2013/03/22/stabilizing-ember-data.html). I'd like
 to give you an update on the status of those efforts.
 
@@ -57,7 +57,7 @@ You go to your manager's office and ask her about it.
 *"Oh yeah,"* she says, *"We didn't have time to learn how to setup an
 existing database, and our needs were pretty simple at the time. We
 decided to roll our own, lightweight database with a simplified query
-language.  I guess it sort of just grew over time as our needs grew."*
+language.  I guess it sort of grew over time as our needs grew."*
 
 Horrified, you tell her that you don't think it's going to be a good
 fit, turn in your badge, and head to your car.

--- a/content/ember-fastboot-1-0-release.md
+++ b/content/ember-fastboot-1-0-release.md
@@ -35,6 +35,7 @@ Therefore, to make sure the developer experience for Ember apps with FastBoot is
 
 This also unlocked the potential to be able to run the server and browser versions of an app during development with a single command: the `ember serve` command Ember developers are already used to.
 
+<!-- alex ignore just -->
 We also exposed an [additional public API](https://github.com/ember-cli/rfcs/pull/80) in Ember CLI that allowed FastBoot to serve index.html with server rendered template using `ember serve`. This API allows any other addon to tap into Ember CLI’s development-time Express server, not just FastBoot.
 
 All of these changes meant that we had to make a hard decision to break some addons’ compatibility with FastBoot. There were many addons that were made FastBoot-compatible (during early adoption), and we tried very hard to make sure these continued to work with this change. However, there was no good way to do so in all cases without compromising the developer experience. Therefore, we realized we had to break some addons that were already FastBoot-compatible. We have a [migration guide](https://gist.github.com/kratiahuja/d22de0fb1660cf0ef58f07a6bcbf1a1c) for addon authors to migrate to the new build strategy, and have already proactively reached out to many addon authors to help them resolve any compatibility issues

--- a/content/ember-fastboot-1-0-release.md
+++ b/content/ember-fastboot-1-0-release.md
@@ -22,7 +22,7 @@ It provides a complete solution for server-side rendering of your app from devel
 FastBoot works by running your Ember app in Node and shipping the rendered HTML of your initial requested route in your index.html (which also contains scripts for your app to boot in browser) to the user.
 This helps you show meaningful content to your user while the JavaScript is being downloaded, and also helps the initial page of your app to paint faster.
 Once the JavaScript downloads and your Ember app in the browser boots, it takes over the initial rendered HTML.
-It also helps the content in your Ember application to be accessible to everyone, even if they have JavaScript disabled.
+It also helps the content in your Ember application to be accessible to everyone, even if they turned off JavaScript.
 
 FastBoot brings in an ecosystem to make it easier for your Ember apps to be built and deployed in a FastBoot-friendly way. To make your Ember app run in FastBoot, you simply need to install the `ember-cli-fastboot` addon and make sure your app runs in Node. After installing the addon, you can continue building and developing your app using the same Ember CLI commands as you would without FastBoot. FastBoot also provides an application server ([`fastboot-app-server`](https://github.com/ember-fastboot/fastboot-app-server)) to run and deploy your Ember app in a Node environment. It manages downloading the Ember app, starting multiple HTTP server processes, and detecting when new versions of the application have been deployed.
 

--- a/content/ember-homepage-survey.md
+++ b/content/ember-homepage-survey.md
@@ -32,7 +32,7 @@ The first version of [emberjs.com](/) was created over 7 years ago, in 2011! Sin
 
 <div class="spacer"></div>
 
-That said, we believe it's time for another redesign of the homepage. The marketing copy doesn't capture many of the amazing innovations that have landed in Ember over the past few years. We want the homepage to reflect just how great it is to be an Ember developer in 2018.
+That said, we believe it's time for another redesign of the homepage. The marketing copy doesn't capture many of the amazing innovations that have landed in Ember over the past few years. We want the homepage to reflect how great it is to be an Ember developer in 2018.
 
 But first we need your help!
 

--- a/content/ember-node-lts-support.md
+++ b/content/ember-node-lts-support.md
@@ -13,7 +13,7 @@ Ember is committed to being a good steward of our collective codebases as part o
 
 ### What does support mean?
 
-All Ember projects can be expected to work in any of the supported Node.js versions and will support every documented feature. We will not maintain separate branches or classes of support for different Node.js support classifications. For example, Ember CLI can be expected to work just the same running on a "Maintenance" Node.js version as it does on a "Current" Node.js version. Not all of our projects presently align to this pattern but we will, over time, coalesce to this state.
+All Ember projects can be expected to work in any of the supported Node.js versions and will support every documented feature. We will not maintain separate branches or classes of support for different Node.js support classifications. For example, Ember CLI can be expected to work the same running on a "Maintenance" Node.js version as it does on a "Current" Node.js version. Not all of our projects presently align to this pattern but we will, over time, coalesce to this state.
 
 Meeting this commitment does not come without cost and tough decisions. However, as maintainers of foundational libraries, we believe that it is in our best interest to validate the legitimacy of the Node.js LTS plans, help position Node.js as a reliable and dependable tool for all enterprises, and contribute toward improving the reputation of the ecosystem.
 

--- a/content/ember-project-at-2-0.md
+++ b/content/ember-project-at-2-0.md
@@ -11,7 +11,7 @@ tags:
 
 For the past several years, when we've talked about "Ember releases", we were always talking about releases of the Ember codebase itself.
 
-In practice, that has meant that in order to put together the full, recommended Ember stack, you needed to figure out not just what Ember version to use, but what versions of our other libraries and tools worked with it.
+In practice, that has meant that in order to put together the full, recommended Ember stack, you needed to figure out not only what Ember version to use, but also what versions of our other libraries and tools worked with it.
 
 Starting with Ember 2.0, we will coordinate every release of Ember with releases of the main ecosystem tools maintained by the core team:
 
@@ -66,6 +66,7 @@ This is not the case if you are trying to upgrade to Ember 2.5 while remaining o
 
 **In practice, the fact that all of these libraries share the same SemVer requirements should make upgrading across all five components more straight forward than trying to cobble together a multi-version stack yourself.**
 
+<!-- alex ignore just -->
 > I don't agree with anything you said here and just want to pick and choose the versions of the libraries I want to use.
 
 Go for it! The people maintaining each of these libraries want older versions of the libraries to work with newer versions of Ember, because it makes their jobs easier.

--- a/content/handlebars-update.md
+++ b/content/handlebars-update.md
@@ -8,9 +8,9 @@ tags:
 ---
 
 
-Handlebars 2.0 was released just a few weeks ago, and since its release we have received many
+Handlebars 2.0 was released a few weeks ago, and since its release we have received many
 requests to update Ember to allow the use of the latest version.  Handlebars 2.0 contains
-a number of changes the list below represents just a few that are likely to affect your
+a number of changes the list below represents a few that are likely to affect your
 Ember application:
 
 * Precompiler output has changed, which breaks compatibility with prior versions of the

--- a/content/inside-fastboot-faking-the-dom-in-node.md
+++ b/content/inside-fastboot-faking-the-dom-in-node.md
@@ -39,7 +39,7 @@ library.
 Importantly, `simple-dom` implements a very, very small subset of the WHATWG
 DOM specification, optimized for performance, and for the requirements
 of the Ember view layer. For example, it does not implement any part of
-the DOM that would require the use of accessors; it's just an attempt to
+the DOM that would require the use of accessors; it only attempts to
 faithfully represent the DOM as a **data structure**, not its complete
 API surface. (If you need the whole enchilada, check out something like
 [jsdom](https://github.com/tmpvar/jsdom), which is much more complete.)
@@ -53,14 +53,15 @@ provided by `simple-dom` rather than relying on the global `document`.
 This week, with our implementation of "the little DOM that could," we were
 able to get more and more sophisticated templates rendering to a string.
 
-First, we started with just a simple template that printed a string:
+First, we started with a simple template that printed a string:
 `<h1>Hello</h1>`.
 
 Then we moved on to bound expressions, so `<h1>Hello {{location}}</h1>`
 became `<h1>Hello World</h1>`.
 
+<!-- alex ignore just -->
 Yesterday, we got `{{#if}}` helpers and nested components working as
-well.  (Other helpers likely work, we just have not written tests for
+well. (Other helpers likely work; we just have not written tests for
 them yet.)
 
 Now that we have bare-bones rendering in place, we are theoretically

--- a/content/inside-fastboot-the-road-to-server-side-rendering.md
+++ b/content/inside-fastboot-the-road-to-server-side-rendering.md
@@ -24,7 +24,7 @@ Solving the whole problem involves not just the view layer, but the entire lifec
 
 We are building this feature into Ember.js, **and we're calling it FastBoot**.
 
-FastBoot will allow you to deliver the HTML and CSS for a page in your Ember app right away, then allow the JavaScript to take over once it has finished loading. Your Ember app will behave no differently than server-rendered apps when it comes to search engines, mobile users, cURL, or users with JavaScript disabled.
+FastBoot will allow you to deliver the HTML and CSS for a page in your Ember app right away, then allow the JavaScript to take over once it has finished loading. Your Ember app will behave no differently than server-rendered apps when it comes to search engines, mobile users, cURL, or users who turned off JavaScript.
 
 For everyone else, you'll still have the responsiveness and interactivity users have come to expect from Ember apps.
 
@@ -68,6 +68,7 @@ This also works fine in tests, with the exception that we are doing more work th
 
 When running on the server, however, we realized that a single Ember application needs to be able to continue serving requests even if a previous request is waiting for an async operation (such as fetching a model) to complete.
 
+<!-- alex ignore host-hostess -->
 This means that we needed to tweak our approach and allow applications to host multiple of what we call "sessions" at a time. Sessions allow us to separate the code registry (which doesn't change once the app is booted) from the application state.
 
 ![Architecture diagram showing state extracted into Session objects](/images/blog/2014-12-22-inside-fastboot-the-road-to-server-side-rendering/new-school.png)

--- a/content/inside-fastboot-the-road-to-server-side-rendering.md
+++ b/content/inside-fastboot-the-road-to-server-side-rendering.md
@@ -20,7 +20,7 @@ In this context, where the JavaScript app looks like a "normal" web page, loadin
 
 Being able to boot JavaScript apps on the server and "rehydrate" in the browser has been considered a Holy Grail for some time. However, most  attempts have focused solely on rendering the view layer on the server into HTML. This is an important step, but this alone does not sufficiently solve the problem.
 
-Solving the whole problem involves not just the view layer, but the entire lifecycle of booting an application: routing, fetching models, and rendering. By leaning heavily on Ember's conventional application structure, we can move this complexity out of each application and into the framework.
+Solving the whole problem involves not only the view layer, but also the entire lifecycle of booting an application: routing, fetching models, and rendering. By leaning heavily on Ember's conventional application structure, we can move this complexity out of each application and into the framework.
 
 We are building this feature into Ember.js, **and we're calling it FastBoot**.
 
@@ -40,7 +40,7 @@ That being said, we have always kept this feature in mind as we were architectin
 
 Even during the most recent HTMLBars effort, which is inherently a DOM-based rendering engine, we made sure to use an [abstraction](https://github.com/tildeio/htmlbars/blob/master/packages/morph/lib/dom-helper.js) whenever we touched the DOM, so that we could swap it out for something else on the server. Similarly, when we designed the router, all communication with the URL went through a "[location](https://github.com/emberjs/ember.js/blob/master/packages/ember-routing/lib/location/api.js)" abstraction, instead of touching the URL bar directly. The routing microlibraries we built ([router.js](https://github.com/tildeio/router.js) and [route-recognizer](https://github.com/tildeio/route-recognizer)) were designed from the beginning to be decoupled from the DOM.
 
-Because of this, we were able to get the Ember framework executing in Node in just a day of work, and were able to get an app completely booted and routing in under a week.
+Because of this, we were able to get the Ember framework executing in Node in one day, and were able to get an app completely booted and routing in under a week.
 
 ## Abstracting Feature Detection
 
@@ -48,7 +48,7 @@ One of the first problems we encountered when trying to execute Ember in node wa
 
 While the vast majority of the subsequent code was resilient to environments without a DOM, the feature detection and helpful assertion messages ("you're using an old version of jQuery") was sloppy because it historically wasn't expecting to run in Node.
 
-To address this issue, we moved all top-level assumptions into [an `environment` abstraction](https://github.com/emberjs/ember.js/blob/master/packages/ember-metal/lib/environment.js). If you look at it, it's really boring; it just lets top-level code throughout the framework quickly short-circuit if basic DOM facilities are missing.
+To address this issue, we moved all top-level assumptions into [an `environment` abstraction](https://github.com/emberjs/ember.js/blob/master/packages/ember-metal/lib/environment.js). If you look at it, it's really boring; it lets top-level code throughout the framework quickly short-circuit if basic DOM facilities are missing.
 
 ## The Container and Session
 

--- a/content/introducing-subteams.md
+++ b/content/introducing-subteams.md
@@ -15,7 +15,7 @@ decision-making and coordination—something we're calling Subteams. We mentione
 some of this in this year's EmberConf keynote, and wanted to expand on the
 specific details.
 
-Ember.js was once just a view layer for rendering templates in the
+Ember.js was once only a view layer for rendering templates in the
 browser, but has grown to become a complete SDK for the web. With one
 `npm install`, you get everything you need to create a modern web
 application.
@@ -109,7 +109,7 @@ While the Ember CLI and Ember Data subteams should be self-explanatory,
 this one is the newest and may require some explanation.
 
 We intentionally did not call this subteam _Documentation_,
-because documentation is just one part of how new users learn to use
+because documentation is only one part of how new users learn to use
 Ember. People start learning the second they land on the website
 homepage, or when they see a presentation at their local user group.
 

--- a/content/making-ember-easier.md
+++ b/content/making-ember-easier.md
@@ -14,7 +14,7 @@ tags:
 We frequently receive feedback from new developers about how frustrating
 it can be to get started with Ember. Yesterday, one of the [most active
 comment threads on Hacker
-News](https://news.ycombinator.com/item?id=5406857) was largely about just that.
+News](https://news.ycombinator.com/item?id=5406857) was largely about that.
 
 <!-- alex ignore easy -->
 We hear you loud and clear. Ember.js is not easy to get started with, and we take that very seriously. We are all working nights and weekends to make the framework as approachable as humanly possible.

--- a/content/mentorship-program.md
+++ b/content/mentorship-program.md
@@ -37,6 +37,7 @@ There wasn't a central online listing of or hub for all these initiatives, and u
 
 EmberConf 2019 will be an annual opportunity to explore new areas for the program(s) to grow. One of the new areas of focus in 2019, for example, will be the first gathering for People of Color in the Ember Community. This Ember POC Connect initiative will be led by Ashlen Price and Elrick Ryan, who you may have met at past EmberConfs!
 
+<!-- alex disable hang -->
 More details are coming soon, and when registration for EmberConf opens, folks will be able to sign up for the first [POC Connect Breakfast](https://emberconf.com/inclusiveness-at-emberconf.html). There's also a new channel is Discord, `#poc-connect`, so people can get to know each other well before they get to hang out at EmberConf.
 
 The Mentorship Program also embraces the idea that opportunities should be available to anyone in the community — not just those who can make it to EmberConf.

--- a/content/new-ember-release-process.md
+++ b/content/new-ember-release-process.md
@@ -41,7 +41,7 @@ Beta and Stable releases will only ship with features that the core team
 believes are stable.
 
 Read on for more details about how we plan to organize new features. If
-you plan to contribute features to Ember.js, or are just interested in
+you plan to contribute features to Ember.js, or are interested in
 the full nitty-gritty, you should check out the [Adding New
 Features](/guides/contributing/adding-new-features) guide, which lays
 out all of the mechanics for the process going forward.

--- a/content/run-up-to-two-oh.md
+++ b/content/run-up-to-two-oh.md
@@ -131,7 +131,7 @@ angle-bracket components.
 {{!-- title is a mutable two-way binding --}}
 {{my-component title=model.name}}
 
-{{!-- title is just an (immutable) value --}}
+{{!-- title is an (immutable) value --}}
 <my-component title={{model.name}} />
 ```
 
@@ -320,7 +320,7 @@ component to modify it. There are only a handful of additional
 characters, but the intent of the code is far clearer, both when the
 component is invoked and when the component is updating the attribute.
 
-In other words, `{{mut}}` just produces a regular JavaScript value that
+In other words, `{{mut}}` produces a regular JavaScript value that
 contains both the current value and a way to update it. The lifecycle
 hooks will fire at the same times as well.
 
@@ -380,7 +380,7 @@ Because `big-button` is simply invoking a function, the invoking
 component can provide whatever function it wants.
 
 Another nice touch, `action` works seamlessly with `mut`. This means
-that from the component's perspective, it's just calling a callback, but
+that from the component's perspective, it's only calling a callback, but
 the code that calls the component can pass in a callback that
 updates one of its values.
 
@@ -407,8 +407,7 @@ into a function that can be invoked.
 
 A component that wishes to support mutable bindings as actions need only
 invoke the callback with a new value. Actions from the `actions` hash,
-and even regular functions passed as `on-enter={{func}}` will work just
-fine.
+and even regular functions passed as `on-enter={{func}}` will work fine.
 
 ### Routeable Components
 

--- a/content/security-incident-aws-s3-key-exposure.md
+++ b/content/security-incident-aws-s3-key-exposure.md
@@ -10,6 +10,8 @@ tags:
 
 
 On November 29th, 2016, the Ember security team was notified that version `2.11.0-beta.1` of the `ember-source` npm package inadvertently included a file that contained an AWS access key. This access key had permissions for full read/write access to the Ember S3 buckets.
+
+<!-- alex ignore host-hostess -->
 These buckets are used to distribute pre-built versions of Ember.js and related libraries and host other static content:
 
 - Ember.js via `builds.emberjs.com`

--- a/content/the-ember-times-issue-101.md
+++ b/content/the-ember-times-issue-101.md
@@ -141,7 +141,7 @@ This is an experiment to see if using decorators and a separate service to manag
 
 ## [One Hundred (and One) Editions of The Ember Times 📰 🎉](https://twitter.com/search?f=tweets&vertical=default&q=%23100EmberTimes)
 
- **The Ember Times**, one of your favourite news outlets about what's going on with Ember and its ecosystem, has just shipped its **one hundredth (and first) edition**! 🎉 The Ember Times now looks back at a long journey that started out over more than three years ago:
+ **The Ember Times**, one of your favourite news outlets about what's going on with Ember and its ecosystem, has shipped its **one hundredth (and first) edition**! 🎉 The Ember Times now looks back at a long journey that started out over more than three years ago:
 
 In its [first release on May 2nd 2016](https://the-emberjs-times.ongoodbits.com/2016/05/03/issue-1), Ember Learning and Framework Core team member **Ricardo Mendes**, also known as [@locks](https://github.com/locks) 🔒, wrote - among many other topics - about the motivation of the newsletter, the recent issue triaging work by [@pixelhandler](https://github.com/pixelhandler) and the [recent implementation efforts](https://github.com/emberjs/ember.js/pull/13316) to get **Glimmer 2**, Ember's super-fast rendering engine, over the finish line. 🏁
 

--- a/content/the-ember-times-issue-102.md
+++ b/content/the-ember-times-issue-102.md
@@ -41,6 +41,7 @@ Here are the highlights from this week's posts:
 
 [@efx](https://github.com/efx) shared [thoughts on existing posts](https://www.typedspace.com/2019-ember-js-roadmap/).
 
+<!-- alex ignore just -->
 > I think we should treat learning as important as the technical ideas that distinguish ember.js. [...] My fabulous colleagues have often asked spot-on, difficult questions about the guide's admonitions to do something a particular way. I too often resort to shallow "that is just the way it is" answers.
 
 ---

--- a/content/the-ember-times-issue-105.md
+++ b/content/the-ember-times-issue-105.md
@@ -95,7 +95,7 @@ Ember Inspector running, so if you would be interested in helping out, please re
 
 ## [Reminder: EmberFest CFP Deadline August 1st 🎤](https://cfp.emberfest.eu/events/emberfest-2019)
 
-A quick reminder that the [EmberFest](https://emberfest.eu/) **CFP deadline** is fast approaching. We are just short of a month away from the **August 1st** deadline, so get your talk in today!
+A quick reminder that the [EmberFest](https://emberfest.eu/) **CFP deadline** is fast approaching. We are only a month away from the **August 1st** deadline, so get your talk in today!
 
 Talks are **30 minutes long** and can range from in-depth technical talks to broader talks covering other aspects of software development.
 

--- a/content/the-ember-times-issue-106.md
+++ b/content/the-ember-times-issue-106.md
@@ -47,7 +47,7 @@ We encourage you to learn today about [Ember Data packages in 3.11](https://embe
 
 Starting with regular HTML and CSS and going through hands-on experience working with glimmer components, tracked properties, actions, and modifiers – the Ember Octane Fundamentals training provides detailed steps in creating your own server-rendered chat application.
 
-What’s even better is that since this is licensed under the BSD-2-Clause, you can feel free to use this material to conduct workshops in your own groups! Just make sure to give some feedback to [@mike-north](https://github.com/mike-north)!
+What’s even better is that since this is licensed under the BSD-2-Clause, you can feel free to use this material to conduct workshops in your own groups! Make sure to give some feedback to [@mike-north](https://github.com/mike-north)!
 
 ---
 

--- a/content/the-ember-times-issue-109.md
+++ b/content/the-ember-times-issue-109.md
@@ -76,7 +76,7 @@ To learn more about exactly how DDAU prevents circular dependencies, we encourag
 
 ## [Together we make EmberJS a better place ✏️](https://github.com/ember-learn/ember-website/pull/373)
 
-We often feature awesome blogposts, intricate RFCs and helpful addons in the Times. But in such a large ecosystem and community, the **small things** also matter. [@backspace](https://github.com/backspace) and [@Imon-Haque](https://github.com/Imon-Haque) both contributed by just changing one file on the Ember website. [Fixing a typo](https://github.com/ember-learn/guides-source/pull/919) or a [broken link](https://github.com/ember-learn/ember-website/pull/373) that you stumble upon might seem really small, but it is valuable because it makes everyone's Ember experience better. So if you find something small, feel free to fix it by clicking the ✏️ on GitHub and creating a PR.
+We often feature awesome blogposts, intricate RFCs and helpful addons in the Times. But in such a large ecosystem and community, the **small things** also matter. [@backspace](https://github.com/backspace) and [@Imon-Haque](https://github.com/Imon-Haque) both contributed by changing one file on the Ember website. [Fixing a typo](https://github.com/ember-learn/guides-source/pull/919) or a [broken link](https://github.com/ember-learn/ember-website/pull/373) that you stumble upon might seem really small, but it is valuable because it makes everyone's Ember experience better. So if you find something small, feel free to fix it by clicking the ✏️ on GitHub and creating a PR.
 
 ---
 

--- a/content/the-ember-times-issue-52.md
+++ b/content/the-ember-times-issue-52.md
@@ -15,7 +15,7 @@ Emberistas שלום! 🐹
 
 Read either on the [Ember blog](https://www.emberjs.com/blog/2018/06/22/the-ember-times-issue-52.html) or in our [e-mail newsletter](https://the-emberjs-times.ongoodbits.com/2018/06/22/the-ember-times-issue-52) what has been going on in Emberland this week.
 
-Those **Request for Comments (RFCs)** just keep coming and this is why we present **4 entirely new** proposals
+Those **Request for Comments (RFCs)** keep coming and this is why we present **4 entirely new** proposals
 that you shouldn't miss this week.
 We also have an amazing **tutorial** for creating **accessible web applications** for you, to give you a head start in developing, shipping and testing your apps for **a11y** 👭
 

--- a/content/the-ember-times-issue-53.md
+++ b/content/the-ember-times-issue-53.md
@@ -43,7 +43,7 @@ Look for this speedup soon in an Ember App near you!
 
 ## [Oh, No(de) He Didn't!](https://github.com/ef4/ember-auto-import)
 
-[Edward Faulkner](https://github.com/ef4) has just released version 1.0 of `ember-auto-import`. This addon allows you to add dependencies using NPM or Yarn with **zero configuration**. It can be used both in apps and addons and deduplicates correctly across all addons and the app itself.
+[Edward Faulkner](https://github.com/ef4) has released version 1.0 of `ember-auto-import`. This addon allows you to add dependencies using NPM or Yarn with **zero configuration**. It can be used both in apps and addons and deduplicates correctly across all addons and the app itself.
 
 All you have to do is type `ember install ember-auto-import` and you’re ready to add whatever dependency you want to your project using NPM or yarn.
 

--- a/content/the-ember-times-issue-54.md
+++ b/content/the-ember-times-issue-54.md
@@ -62,7 +62,7 @@ get all the TypeScript neatness to your test suite today and type on! ⌨
 Some cool updates are **new keyboard shortcuts** for `run now` and `save` as well as a shortcut for quickly commenting JavaScript code.
 There are also some updates to the contribution guide and of course it now supports Ember 3.0 - 3.2 out of the box!
 
-Ember Twiddle, currently at `v0.15.0` is a great tool that allows creating simple Ember apps to showcase ideas, bugs, issues, demos and more. It allows using addons with the included `twiddle.json` and has a built-in generator just like Ember-CLI. There are even different keyboard layouts such as Vim, Emacs, Sublime and more.
+Ember Twiddle, currently at `v0.15.0` is a great tool that allows creating simple Ember apps to showcase ideas, bugs, issues, demos and more. It allows using addons with the included `twiddle.json` and has a built-in generator like Ember-CLI. There are even different keyboard layouts such as Vim, Emacs, Sublime and more.
 
 Now is a great time to check out this amazing tool!
 

--- a/content/the-ember-times-issue-55.md
+++ b/content/the-ember-times-issue-55.md
@@ -27,9 +27,9 @@ This week you can learn about **updating** your Ember app 💁🏻. Learn from f
 
 ## [Don't Worry, Ember CLI Got You Covered 💻](https://github.com/ember-cli/ember-cli-update)
 
-The **number one** tool for updating Ember.js apps or addons just got **even better**. The [newest version](https://github.com/ember-cli/ember-cli-update/releases) of `ember-cli-update` now runs `qunit-dom-codemod` for you. This means that you, with close to no effort at all, can utilize this great addon for your tests.
+The **number one** tool for updating Ember.js apps or addons got **even better**. The [newest version](https://github.com/ember-cli/ember-cli-update/releases) of `ember-cli-update` now runs `qunit-dom-codemod` for you. This means that you, with close to no effort at all, can utilize this great addon for your tests.
 
-And the cool thing is that `ember-cli-update` fetches new codemods **during runtime** - so no need to update to get this nice codemod! To run the codemod just type `ember-cli-update --run-codemods` and magic will take care of the rest for you.
+And the cool thing is that `ember-cli-update` fetches new codemods **during runtime** - so no need to update to get this nice codemod! To run the codemod, type `ember-cli-update --run-codemods` and magic will take care of the rest for you.
 
 You can visit the addon page for [ember-cli-update](https://github.com/ember-cli/ember-cli-update) to read all about it or visit [qunit-dom](https://github.com/simplabs/qunit-dom) to learn about all the nice features it provides.
 

--- a/content/the-ember-times-issue-56.md
+++ b/content/the-ember-times-issue-56.md
@@ -29,7 +29,7 @@ in an Ember app near you soon! 🚀
 
 ## [Got Dependencies? 📦](https://github.com/ef4/ember-auto-import#dynamic-import)
 
-We’ve previously highlighted the great `ember-auto-import` by the wizardly [Edward Faulkner](https://github.com/ef4)🌟 as a way to import npm packages into your Ember app. With the latest update it just got way cooler.
+We’ve previously highlighted the great `ember-auto-import` by the wizardly [Edward Faulkner](https://github.com/ef4)🌟 as a way to import npm packages into your Ember app. With the latest update, it got way cooler.
 
 As he demonstrates in this [nice screencast](https://eaf4.com/dynamic-import-into-your-ember-app/), with v1.2.0 you can now lazy load dependencies via `import()`! The dynamic `import()` will load the dependency as well as all its recursive dependencies via a separate JavaScript file **at runtime**. That’s really awesome.
 

--- a/content/the-ember-times-issue-57.md
+++ b/content/the-ember-times-issue-57.md
@@ -51,6 +51,7 @@ The first stream about writing and refactoring Ember Data's test suite already w
 
 ---
 
+<!-- alex ignore just -->
 ## [Ember + WebAssembly just got way easier](https://medium.com/@lukedeniston/ember-webassembly-just-got-way-easier-1e4ec6ca40ab)
 
 Thanks to @ef4's [ember-auto-import](https://github.com/ef4/ember-auto-import), importing Wasm modules is now a breeze! [@luketheobscure](https://github.com/luketheobscure) wrote about his experience and created a [wasm-example app](https://github.com/luketheobscure/wasm-example) in Ember. Check out his writeup on [Medium](https://medium.com/@lukedeniston/ember-webassembly-just-got-way-easier-1e4ec6ca40ab).

--- a/content/the-ember-times-issue-59.md
+++ b/content/the-ember-times-issue-59.md
@@ -19,7 +19,7 @@ Merhaba Emberistas! 🐹
 Read either on the [Ember blog](https://emberjs.com/blog/tags/newsletter.html) or in our [e-mail newsletter](https://the-emberjs-times.ongoodbits.com/) what has been going on in Emberland this week.
 
 <!--alex ignore dive-->
-This week's edition is jammed packed! Take a journey and find out how to use Ember to create **Chrome Extensions**. Test drive the latest **Ember-CLI beta** features.  Dive deep into the **Component Manager Bounds** RFC. Learn how to help ship **Mirage 1.0**.  Need Ember powered **A/B experiments** ? Outdoorsy open sourced an addon that might just help.
+This week's edition is jammed packed! Take a journey and find out how to use Ember to create **Chrome Extensions**. Test drive the latest **Ember-CLI beta** features.  Dive deep into the **Component Manager Bounds** RFC. Learn how to help ship **Mirage 1.0**.  Need Ember powered **A/B experiments** ? Outdoorsy open sourced an addon that might help.
 
 <!-- READMORE -->
 

--- a/content/the-ember-times-issue-60.md
+++ b/content/the-ember-times-issue-60.md
@@ -26,7 +26,7 @@ This week's Ember Times is all about **cool web fonts** 😎, community **chat**
 
 ## [Taking Web Fonts to the Next Level 🔠](https://github.com/vitch/ember-cli-webfont)
 
-Do you like web fonts? Of course you do! Then it’s a good thing that `ember-cli-webfonts` just released version 1.0 🎉
+Do you like web fonts? Of course you do! Then it’s a good thing that `ember-cli-webfonts` released version 1.0 🎉
 
 Now you can use the `webfonts-generator` to **generate web fonts** as part of your ember build process. By default the addon expects to find SVG files in `app/webfont-svg` but all of this can be customised alongside with class prefixes, base selectors, font names and much more.
 

--- a/content/the-ember-times-issue-63.md
+++ b/content/the-ember-times-issue-63.md
@@ -25,7 +25,7 @@ Be sure to join the new Ember community chat on Discord 💬! This week, you can
 
 ## [Meet your Ember 🐹 friends at Discord 🗨](https://discord.gg/zT3asNS)
 
-The time has come: The **Ember Community is starting its big move over to [Discord](https://discord.gg/zT3asNS)**. As proposed in the [original and just recently accepted RFC (Request For Comments) for the migration](https://github.com/emberjs/rfcs/pull/345) you can now **chat** with your **Ember friends** 🐹👭👬👫 from all around the world on the Ember Discord server. This comes - among other benefits - with the advantage of **unlimited message history**.
+The time has come: The **Ember Community is starting its big move over to [Discord](https://discord.gg/zT3asNS)**. As proposed in the [original and recently accepted RFC (Request For Comments) for the migration](https://github.com/emberjs/rfcs/pull/345) you can now **chat** with your **Ember friends** 🐹👭👬👫 from all around the world on the Ember Discord server. This comes - among other benefits - with the advantage of **unlimited message history**.
 
 [Check out the new community chat today](https://discord.gg/zT3asNS), be sure to **set up your profile** as described in the `#setup-profile` channel and to join `#discord-server-admin` to gain access to your favorite discussions 💬.
 

--- a/content/the-ember-times-issue-64.md
+++ b/content/the-ember-times-issue-64.md
@@ -26,7 +26,7 @@ This week we're sharing news about the 🆕 Ember community Discord chat 💬, s
 It's done! 👌 The **community chat has** finally **moved** over to [Discord](https://discordapp.com/)!
 Even more **modern** than _IRC_ and _ICQ_ combined, you can now chat with other Emberistas from all around the globe in many different topic channels with **unlimited message history** 💌✨.
 
-[Join today](https://discord.gg/zT3asNS) and be sure to get setup as described in the `#setup-profile` channel. To start chatting, request the _community-member_ role in `#discord-server-admin`, so the undaunted org admins can make sure THAT YOU ARE NOT A BOT BUT A REAL HUMAN JUST LIKE US HA-HA 🤖.
+[Join today](https://discord.gg/zT3asNS) and be sure to get setup as described in the `#setup-profile` channel. To start chatting, request the _community-member_ role in `#discord-server-admin`, so the undaunted org admins can make sure THAT YOU ARE NOT A BOT BUT A REAL HUMAN LIKE US HA-HA 🤖.
 
 ---
 
@@ -42,6 +42,7 @@ Curious? [**Read the full proposal**](https://github.com/emberjs/rfcs/pull/372) 
 
 ## [State of JavaScript 2018 Survey Is Here Again 🗳️](https://medium.freecodecamp.org/take-the-state-of-javascript-2018-survey-c43be2fcaa9)
 
+<!-- alex ignore just -->
 "Just like [the holidays] or the flu, the **State of JavaScript** survey comes back around every year. But unlike these, it’s something to actually look forward to!" - [Sacha Greif](https://twitter.com/SachaGreif/status/1037603748917403648)
 
 [State of JavaScript](https://stateofjs.com/) is **the** yearly JavaScript survey that aims to gauge the whole JavaScript community across all frameworks, libraries, regional location and more. It tries to find out with which technologies developers are **most happy** with as well as which technologies are coming up and becoming popular in JavaScript.

--- a/content/the-ember-times-issue-66.md
+++ b/content/the-ember-times-issue-66.md
@@ -52,7 +52,7 @@ Check it out on the [GitHub repo](https://github.com/mixonic/ember-cli-deprecati
 
 Ever had the need to read **query params (QPs)** off a `Controller` and pass it down to a component to change its UI state depending on the QP value?
 
-Ever had a hard time passing down QP values through layers and layers of components to do just that?
+Ever had a hard time passing down QP values through layers and layers of components?
 
 It doesn't have to be this way. Read [this new RFC](https://github.com/emberjs/rfcs/pull/380) about exposing QPs as a _computed property_ on the `RouterService`. It proposes that this `Service` can then be injected into components, which makes laborious passing of QP data obsolete.
 
@@ -73,7 +73,7 @@ Going forward the plan is to provide better testing for cases like this so you a
 Inspired by **Module Unification**, [@NullVoxPopuli](https://github.com/NullVoxPopuli) has
 written an article on **general project structure for single page apps.**
 In the article he explains how structure is not specific to Ember, React, Vue, or anything else,
-but just needs to meet a set of guidelines for some common desired goals.
+but needs to meet a set of guidelines for some common desired goals.
 
 Read it here: [_A general and flexible file structure that works for all projects in any ecosystem_](https://dev.to/nullvoxpopuli/a-general-and-flexible-file-structure-that-works-for-all-projects-in-any-ecosystem-1lp9)
 

--- a/content/the-ember-times-issue-67.md
+++ b/content/the-ember-times-issue-67.md
@@ -52,7 +52,7 @@ Of course we want to give a shoutout to [@Gaurav0](https://github.com/Gaurav0) a
 
 There are of course a few issues that Mike is working on fixing, but we believe that this will be stable and usable soon. For example, `ember new app` doesn't work.
 
-To try this out today just use this [starter kit](https://codesandbox.io/s/github/mike-north/ember-new-output/tree/vanilla) or if you are feeling **adventurous** try out this [TypeScript starter kit](https://codesandbox.io/s/github/mike-north/ember-new-output/tree/typescript).
+To try this out today, use this [starter kit](https://codesandbox.io/s/github/mike-north/ember-new-output/tree/vanilla) or if you are feeling **adventurous** try out this [TypeScript starter kit](https://codesandbox.io/s/github/mike-north/ember-new-output/tree/typescript).
 
 To learn more make sure to check out the [blog post](https://medium.com/@mikenorth/ember-community-meet-codesandbox-10a43076b3fa) and follow [Mike on Twitter](https://twitter.com/michaellnorth/status/1047231228020023296) to stay updated!
 

--- a/content/the-ember-times-issue-68.md
+++ b/content/the-ember-times-issue-68.md
@@ -54,7 +54,7 @@ See the full list on the [cli-guides-source Quest issue](https://github.com/embe
 
 Have you heard of **Ember's future default project layout**? If you haven't, you can read about it the [Module Unification RFC](https://github.com/emberjs/rfcs/blob/master/text/0143-module-unification.md).
 
-The initial work on Module Unification is **nearly complete**, as **[there are only a handful of tasks left](https://github.com/emberjs/ember.js/issues/16373)** and some of the tasks just need a good amount of spelunking time.
+The initial work on Module Unification is **nearly complete**, as **[there are only a handful of tasks left](https://github.com/emberjs/ember.js/issues/16373)** and some of the tasks need a good amount of spelunking time.
 If you can donate some of your time to help finish this up, the entire community will forever be in your debt. 💖
 
 Also, if you are a user of namespaced components, [this RFC](https://github.com/emberjs/rfcs/pull/367) is a must read. Please leave your thoughts on the [Module Unification Packages RFC](https://github.com/emberjs/rfcs/pull/367) as nested components affect the majority of Ember projects.

--- a/content/the-ember-times-issue-72.md
+++ b/content/the-ember-times-issue-72.md
@@ -48,7 +48,7 @@ There are more proposed solutions in [the RFC](https://github.com/emberjs/rfcs/b
 
 Have you ever wanted to **track** specific keywords for a particular route in your Ember app, but didn't know how to do so in an elegant fashion? Have you tried to update the `document.title` of a page depending on the specific point of time at which a route was visited, but realized that this couldn't be done without some effort?
 
-Then a brand-new **Request for Comments (RFC)** is just for you! The proposal [_RouteInfo Metadata_](https://github.com/emberjs/rfcs/pull/398) suggests a new way for reading and writing **application-specific metadata** to the corresponding _RouteInfo_ object. For more context on which information routes currently provide, be sure to also check out [the section about the RouteInfo type from the original RouterService RFC](https://github.com/emberjs/rfcs/blob/master/text/0095-router-service.md#routeinfo-type).
+Then a brand-new **Request for Comments (RFC)** is for you! The proposal [_RouteInfo Metadata_](https://github.com/emberjs/rfcs/pull/398) suggests a new way for reading and writing **application-specific metadata** to the corresponding _RouteInfo_ object. For more context on which information routes currently provide, be sure to also check out [the section about the RouteInfo type from the original RouterService RFC](https://github.com/emberjs/rfcs/blob/master/text/0095-router-service.md#routeinfo-type).
 
 And finally, read the full _RouteInfo Metadata_ proposal to learn more and leave your thoughts and questions in the [comments below the proposal](https://github.com/emberjs/rfcs/pull/398).
 

--- a/content/the-ember-times-issue-76.md
+++ b/content/the-ember-times-issue-76.md
@@ -43,7 +43,7 @@ The [Tracked Properties RFC](https://github.com/emberjs/rfcs/blob/be351b059f08ac
 Developers can identify if a property or a getter should be _autotracked_  by adding a `@tracked` decorator to it. This allows that value to have its dependencies automatically detected as it is used.
 
 <!--alex ignore special-->
-Because tracked properties are just a very thin layer on top of native JavaScript, setting and accessing tracked properties can be done using **standard JavaScript syntax**. With no special syntax, and leveraging existing JavaScript knowledge.
+Because tracked properties are a very thin layer on top of native JavaScript, setting and accessing tracked properties can be done using **standard JavaScript syntax**. With no special syntax, and leveraging existing JavaScript knowledge.
 
 Comment and read more about the [RFC on GitHub](https://github.com/emberjs/rfcs/pull/410).
 

--- a/content/the-ember-times-issue-77.md
+++ b/content/the-ember-times-issue-77.md
@@ -23,7 +23,7 @@ This week boolean component arguments 👻 are in for an RFC, learn more about c
 
 ## [Boolean Dreams Come True ☁️](https://github.com/emberjs/rfcs/pull/407)
 
-Ever wanted to pass **boolean arguments** to your **components** _just_ like you would pass boolean attributes - like checked or readonly - to an HTML element?
+Ever wanted to pass **boolean arguments** to your **components** like you would pass boolean attributes - like checked or readonly - to an HTML element?
 
 This fresh [RFC (Request for Comments) discusses how this could become reality](https://github.com/hakubo/rfcs/blob/component-boolean-arguments/text/0000-component-boolean-arguments.md)!
 

--- a/content/the-ember-times-issue-78.md
+++ b/content/the-ember-times-issue-78.md
@@ -102,7 +102,7 @@ The [RFC](https://github.com/pzuraq/emberjs-rfcs/blob/render-element-modifiers/t
 ## [The Ember Mentorship Program 👨‍🎓👩‍🎓](https://www.emberjs.com/blog/2018/12/17/mentorship-program.html)
 
 This week the new **Ember Mentorship Program** [has been officially announced](https://www.emberjs.com/blog/2018/12/17/mentorship-program.html)!
-It aims to guide the next wave of Ember developers of all experience levels into the community. By making developers succeed in [public speaking](https://emberconf.com/mentorship-program.html#evangelism), finding their space [in a supportive peer group](https://emberconf.com/mentorship-program.html#women-helping-women) or [leveling up their engineering skills](https://emberconf.com/mentorship-program.html#general-mentorship) the program is meant **just for you**!
+It aims to guide the next wave of Ember developers of all experience levels into the community. By making developers succeed in [public speaking](https://emberconf.com/mentorship-program.html#evangelism), finding their space [in a supportive peer group](https://emberconf.com/mentorship-program.html#women-helping-women) or [leveling up their engineering skills](https://emberconf.com/mentorship-program.html#general-mentorship) the program is **meant for you**!
 
 Learn all about [the Ember Mentorship Program and join the community](https://emberconf.com/mentorship-program.html)!
 

--- a/content/the-ember-times-issue-80.md
+++ b/content/the-ember-times-issue-80.md
@@ -26,7 +26,7 @@ This week you can read about the 🦄 *magical gifts* 🎁  of **DecEmber** ❄ 
 
 [DecEmber](https://www.emberjs.com/blog/2018/11/29/december-event.html) has wrapped up and it seems to have been a big hit! There were many contributions to `ember-learn` repos and it is all thanks to the awesome Ember community!
 
-Did you participate in **DecEmber**? We'd like to send you a thank you gift! Just [fill out the form](https://airtable.com/shrm9o5W89wsAa1Tq) and enjoy!
+Did you participate in **DecEmber**? We'd like to send you a thank you gift! [Fill out the form](https://airtable.com/shrm9o5W89wsAa1Tq) and enjoy!
 
 ---
 

--- a/content/the-ember-times-issue-84.md
+++ b/content/the-ember-times-issue-84.md
@@ -56,7 +56,7 @@ As if that wasn't enough, ember-cli-mirage currently has **0 reproducible bugs**
 
 A **new, dark theme** for [Ember Twiddle](https://ember-twiddle.com/) now allows you to create, edit and share Ember code snippets in a stylish way 🖤.
 
-The project [Ember Twiddle Solarized](https://github.com/sukima/ember-twiddle-solarized) is a UserCSS theme that can be installed in either Firefox, Chrome or Opera in just a few steps.
+The project [Ember Twiddle Solarized](https://github.com/sukima/ember-twiddle-solarized) is a UserCSS theme that can be installed in either Firefox, Chrome or Opera in a few steps.
 [Check out the installation instructions](https://github.com/sukima/ember-twiddle-solarized#installation-solarized#installation) and start twiddling today!
 
 ---

--- a/content/the-ember-times-issue-93.md
+++ b/content/the-ember-times-issue-93.md
@@ -82,6 +82,7 @@ By choosing Ember, you can **save your development team time**, particularly onc
 
 But it can be **challenging** to sway folks outside of the community to Ember. For example, another survey respondent shared:
 
+<!-- alex ignore just -->
 > [Ember] just isn't used broadly enough in my part of the country to encourage people in that direction. The exception is for a large team that is starting from scratch - there I would recommend it still.
 
 This quote reminded us of our past Readers’ Question from [@kategengler](https://github.com/kategengler), where she discussed ["How do I pitch Ember at my company?"](https://discuss.emberjs.com/t/readers-questions-how-do-i-pitch-ember-at-my-company/14289) We thought it would be worthwhile to share some of her tips again:
@@ -102,7 +103,7 @@ Of course the community survey highlights and reinforces so many of the aspects 
 
 Specifically the survey **empowers** community members, gives us a voice and a chance to comment about [how we feel Ember can improve](https://emberjs.com/ember-community-survey-2019/#how-can-we-improve-ember). Some shout-outs this year include continuing to broaden and diversify opinions, lighter builds and less Ember-specific syntax.
 
-Also, some of the [excellent talks](https://www.youtube.com/playlist?list=PLE7tQUdRKcyYWLWrHgmWsvzsQBSWCLHYL) we heard at EmberConf in 2019, like [@MelSumner](https://github.com/melsumner)'s amazing talk [Don't Break The Web](https://noti.st/melsumner/Phhimm/dont-break-the-web), highlighted the importance of improving accessibility not just in Ember, but across the web as a whole.  
+Also, some of the [excellent talks](https://www.youtube.com/playlist?list=PLE7tQUdRKcyYWLWrHgmWsvzsQBSWCLHYL) we heard at EmberConf in 2019, like [@MelSumner](https://github.com/melsumner)'s amazing talk [Don't Break The Web](https://noti.st/melsumner/Phhimm/dont-break-the-web), highlighted the importance of improving accessibility not only in Ember, but also across the web as a whole.  
 
 The results of the survey's [skillset self-appraisal](https://emberjs.com/ember-community-survey-2019/#stack-skills) underscore this point. While many survey participants identified themselves as possessing advanced skills in areas like Ember, JavaScript, HTML and CSS, almost 70% of participants self-identified at a beginner level skill regarding Accessible Rich Internet Applications (ARIA). So it turns out many of us can improve our skills in building **accessible applications**, let's seize the opportunity to improve and act on this data! ✨💪✨
 

--- a/content/the-ember-times-issue-94.md
+++ b/content/the-ember-times-issue-94.md
@@ -107,7 +107,7 @@ Read [@matixmatix](https://github.com/matixmatix)'s full [tutorial](https://code
 
 ## [Code Splitting on Routes 🖖](https://twitter.com/acorncom/status/1111827571803471872)
 
-In [Embroider](https://github.com/embroider-build/embroider), an experimental build system for EmberJS, [@ef4](https://github.com/ef4) [added](https://github.com/embroider-build/embroider/pull/109) the `splitAtRoutes` option along with the `@embroider/router` package to enable per **route code splitting**. Ember applications can start testing route code splitting by just sticking to community conventions.
+In [Embroider](https://github.com/embroider-build/embroider), an experimental build system for EmberJS, [@ef4](https://github.com/ef4) [added](https://github.com/embroider-build/embroider/pull/109) the `splitAtRoutes` option along with the `@embroider/router` package to enable per **route code splitting**. Ember applications can start testing route code splitting by sticking to community conventions.
 
 Try out [Embroider](https://github.com/embroider-build/embroider) today!
 

--- a/content/the-ember-times-issue-96.md
+++ b/content/the-ember-times-issue-96.md
@@ -76,6 +76,7 @@ Be sure to look out for an RFC to make Embroider the next build system for Ember
 
 ## [Building with Octane, by Beto Cantú 🔥](https://www.youtube.com/watch?v=KnkWs18V9dA)
 
+<!-- alex ignore just -->
 At the inaugural [Ember San Antonio Meetup](https://www.meetup.com/EmberSA), Beto Cantú ([@betocantu93](https://github.com/betocantu93)) presented [an e-commerce app that he had built](https://github.com/betocantu93/octane-ecommerce) with [Octane](https://emberjs.com/editions/octane/) (in just hours!).
 
 In addition to new features such as `@tracked` and `{{on}}` modifier, Beto covered the fundamentals of Ember—from designing routes to deploying our app. This made a great introduction to attendees who had never used Ember before. 🤗

--- a/content/the-ember-times-issue-98.md
+++ b/content/the-ember-times-issue-98.md
@@ -126,7 +126,7 @@ We encourage you to [read and share the blog post](https://medium.com/ember-ish/
 
 On May 16th, **Global Accessibility Awareness Day (GAAD)** inspired developers all around the world to reflect on the way they use and build applications for the web. In her [recent call-to-action for GAAD](https://blog.emberjs.com/2019/05/13/global-accessibility-awareness-day.html) 📣, [@MelSumner](https://github.com/MelSumner) encouraged the Ember community to take the time to browse the web using keyboard or an assistive technology, and to spend time to improve accessibility in their own projects.
 
-Addon author [@josemarluedke](https://github.com/josemarluedke) followed this call-to-action and just published [Ember Focus Trap](https://github.com/josemarluedke/ember-focus-trap)! It's based on the JavaScript library [Focus Trap](https://github.com/davidtheclark/focus-trap) that helps you to intentionally trap focus in certain DOM nodes. This helps you improve the keyboard accessibility of otherwise inaccessible elements such as modal dialogs.
+Addon author [@josemarluedke](https://github.com/josemarluedke) followed this call-to-action and published [Ember Focus Trap](https://github.com/josemarluedke/ember-focus-trap)! It's based on the JavaScript library [Focus Trap](https://github.com/davidtheclark/focus-trap) that helps you to intentionally trap focus in certain DOM nodes. This helps you improve the keyboard accessibility of otherwise inaccessible elements such as modal dialogs.
 
 With **Ember Focus Trap**, adding focus to interactive elements in your Ember app is only an `ember install` away. Check it [out today](https://josemarluedke.github.io/ember-focus-trap/)!
 

--- a/content/the-ember-times-issue-99.md
+++ b/content/the-ember-times-issue-99.md
@@ -48,9 +48,9 @@ Note: Releases are **considered done** when the [blog post](https://blog.emberjs
 
 Building a [Fastboot](https://ember-fastboot.com/) powered Ember application? Struggling with **writing meaningful tests** for it, that take into account outgoing network requests?
 
-Imagine if you could **mock network requests** for your Fastboot test suite with ease, just as you already do using [Ember CLI Mirage](https://www.ember-cli-mirage.com/) when testing the client-side of your app.
+Imagine if you could **mock network requests** for your Fastboot test suite with ease, like you do with [Ember CLI Mirage](https://www.ember-cli-mirage.com/) when testing the client-side of your app.
 
-Your testing dreams have just come true! [Ember CLI Fastboot Testing](https://embermap.github.io/ember-cli-fastboot-testing/) provides you with useful test helpers and a mock server for intercepting requests from your Fastboot app while testing. Learn how to mock network requests with it by checking out this [amazing introduction](https://embermap.com/video/fastboot-network-mocking) by [our friends at EmberMap](https://embermap.com) and test away! ✨
+Your testing dreams can come true! [Ember CLI Fastboot Testing](https://embermap.github.io/ember-cli-fastboot-testing/) provides you with useful test helpers and a mock server for intercepting requests from your Fastboot app while testing. Learn how to mock network requests with it by checking out this [amazing introduction](https://embermap.com/video/fastboot-network-mocking) by [our friends at EmberMap](https://embermap.com) and test away! ✨
 
 ---
 

--- a/content/the-emberjs-times-issue-49.md
+++ b/content/the-emberjs-times-issue-49.md
@@ -65,6 +65,7 @@ with Ember Data, you know that it is essentially a process of translating things
 in JavaScript before it goes into Ember Data. If you're using JSON:API upfront, things are a lot
 easier to deal with, and you get to make use of the simplicity of Ember Data.
 
+<!-- alex ignore just -->
 Broccoli is an **asset pipeline** that deals very effectively with the file system. It is Just Javascript™️ in theory. One of the issues that makes Broccoli more
 challenging to work with is the lack of documentation, or at least that _used_ to be the case. Over
 the last few months, [Oli Griffiths](https://github.com/oligriffiths) has been very active in the
@@ -83,7 +84,7 @@ Since the early days of `broccoli-static-site-json`, things have gotten a tiny b
 
 ## The main plugin
 
-The simple early experiment of the `broccoli-static-site-json` had an `index.js` file (the only active file at the time) with a total of 119 lines of code, the main active lines making up the `build()` of the Broccoli plugin just adding up to 50 lines of code, which is definitely small enough for us to deep dive into in this post. 💪
+The simple early experiment of the `broccoli-static-site-json` had an `index.js` file (the only active file at the time) with a total of 119 lines of code, the main active lines making up the `build()` of the Broccoli plugin only adding up to 50 lines of code, which is definitely small enough for us to deep dive into in this post. 💪
 
 I'm going to give a brief overview of the structure of a Broccoli plugin and then go into detail of each line of the main `build()` function.
 
@@ -175,7 +176,7 @@ This may seem a bit scary, but don't worry we will break it down, and hopefully 
 
 #### Creating the output folder
 
-The first piece is just a bit of housecleaning. We want to make sure the output folder exists before we continue and if it doesn't we need to create it:
+The first piece is a bit of housecleaning. We want to make sure the output folder exists before we continue and if it doesn't we need to create it:
 
 ```javascript
 // build content folder if it doesn't exist
@@ -319,7 +320,7 @@ const ContentSerializer = new Serializer('content', {
 });
 ```
 
-In this case we use `keyForAttribute()` to rename `__content` to just be `content`.
+In this case we use `keyForAttribute()` to rename `__content` to be `content`.
 
 ## Conclusion
 

--- a/content/the-emberjs-times-issue-51.md
+++ b/content/the-emberjs-times-issue-51.md
@@ -45,7 +45,7 @@ But what about all the other cool things that we mentioned in previous editions 
 When are all of these proposal finally gonna land?
 
 Features which haven't found their way into a stable release and have not been recommended by the [official Guides](https://github.com/ember-learn/guides-app) yet,
-might in fact have landed already. Like a hidden gem they just sit there for a while, only noticed by a few,
+might in fact have landed already. Like a hidden gem, they sit there for a while, only noticed by a few,
 but still ready to be tested and improved until they make it into a stable release.
 And so it seems some of the most exciting API changes in Ember this year have still **gone unnoticed**:
 But [AngleBracketComponents](#toc_a-href-https-github-com-rwjblue-ember-named-arguments-polyfill-back-to-the-future-a),

--- a/content/the-road-to-ember-data-1-0.md
+++ b/content/the-road-to-ember-data-1-0.md
@@ -20,8 +20,8 @@ can confidently make guarantees around not breaking the API. Specifically:
 2. All relationships will become async, but DataBoundPromises will make them
    work well in observers, computed properties and in templates.
 
-Just like how it took us a few attempts to get the router right—but now we've
-got the best one in JavaScript—getting Ember Data right has taken longer than
+Recall how it took us a few attempts to get the router right, but now we've
+got the best one in JavaScript. Getting Ember Data right has taken longer than
 we thought, but it's here and it's almost ready for a 1.0.
 
 * * *
@@ -64,6 +64,7 @@ domain-specific relationships quickly ends up with their own ad hoc
 mini-framework. As we did with Ember, we wanted to look at the problems shared
 across all of these applications, and tease out the core abstractions.
 
+<!-- alex ignore just -->
 We wanted to build something that was powerful, to help save time for advanced
 developers, while also being accessible to developers just getting started with
 client-side web applications.
@@ -96,7 +97,7 @@ I'll spare you the details, but the permutations get even more complex when you
 introduce things like streaming changes from the server over a socket.
 
 The point of highlighting the essential complexity here is to demonstrate that
-we couldn't just hardcode support for each one; each representation will likely
+we couldn't hardcode support for each one; each representation will likely
 co-exist and interoperate with multiple other representations.
 
 One-way relationships aren't too bad--you can get pretty far with hand-rolled
@@ -177,7 +178,7 @@ an Ember Data relationship in a template or in a computed property? How would
 that work?
 
 Ember Data 1.0 introduces a subclass of Promise called `DataBoundPromise`. This
-object allows you to observe properties on the Promise, just as you would on a
+object allows you to observe properties on the Promise, as you would on a
 normal object. When the promise resolves, those properties will be updated to
 match the underlying object. If you `get` a property from a `DataBoundPromise`
 when it is unresolved, it will return `undefined`.
@@ -230,6 +231,7 @@ Earlier on, when we started with Ember Data, we tried to codify good practices, 
 
 In order to make sure that the community would still be able to build on top of the Ember Data abstraction, we tried our best to isolate the code that is different between applications to the Adapter. This means that if someone writes a plugin for Ember Data, they can assume that models and relationships will look the same in all apps that use it, even though application backends can vary considerably.
 
+<!-- alex ignore just -->
 In earlier versions of Ember Data, we were too religious about this separation, forcing every application to bear significant costs in the adapter layer. When we rebooted Ember Data six months ago, we took a hard look at striking a better balance between these competing concerns. Based on the feedback we've gotten since then, we believe that Ember Data is now a great fit for applications that have very unique backends, as well as applications that want direction on how to build a backend that "just works" with Ember Data.
 
 We are committed to getting things right before declaring 1.0. The router in Ember.js went through several similar iterations, which were painful at the time, but we believe the results speak for themselves. Adapting to real-world usage is an important part of our design process, and we will always prioritize thinking through problems carefully over rushing to ship.

--- a/content/this-week-in-ember-js-2.md
+++ b/content/this-week-in-ember-js-2.md
@@ -83,9 +83,8 @@ around the place.
 
 ### Meetups
 
-Zendesk is hosting the [SF Ember.js Meetup](http://www.meetup.com/Ember-SF/events/89198892/)
-on Tuesday 4 December, if you're in the area please head along and
-hang out with fellow Emberenõs.
+<!-- alex disable hang -->
+Zendesk is hosting the [SF Ember.js Meetup](http://www.meetup.com/Ember-SF/events/89198892/) on Tuesday 4 December, if you're in the area please head along and hang out with other Emberenõs.
 
 Likewise, Tom Dale and Yehuda Katz will be making an
 appearance at the [Seattle Ember.js DecEMBER Meetup](http://www.meetup.com/Ember-js-Seattle-Meetup/events/68465172/)

--- a/content/this-week-in-ember-js-3.md
+++ b/content/this-week-in-ember-js-3.md
@@ -54,6 +54,7 @@ for more information.
 
 ### Bound handlebars helpers
 
+<!-- alex ignore just -->
 Ember.Handlebars just got a little bit smarter. `Ember.Handlebars.registerBoundHelper`
 provides a way to create your own bound custom helpers.
 

--- a/content/this-week-in-ember-js-4.md
+++ b/content/this-week-in-ember-js-4.md
@@ -84,7 +84,7 @@ overwhelmingly positive. While we've had to make several tweaks over the
 past month to make sure the API is as intuitive as possible, the overall
 concepts behind the API have remained stable.
 
-We believe that we've finally worked out all of the kinks, and do not
+We believe that we've finally worked out the edge cases, and do not
 have any plans to make any further backwards-incompatible changes to the
 router API before the final 1.0 release.
 
@@ -156,7 +156,7 @@ bring them up to a similarly polished look-and-feel as the guides.
 
 ## Thanks
 
-We've been working on Ember.js for just over a year now, and it's no
+We've been working on Ember.js for a little over a year now, and it's no
 understatement to say that it has attracted some of the best and
 brightest web engineers on the planet. It has been extremely gratifying
 to see our ideas take form, and we can't wait to see what 2013 holds for

--- a/content/this-week-in-ember-js.md
+++ b/content/this-week-in-ember-js.md
@@ -45,7 +45,7 @@ This feature is done and on `master`!
 
 Ember Data has always been smart enough to know that when you set a `belongsTo` relationship, the child record should be added to the parent's corresponding `hasMany` relationship.
 
-Unfortunately, it was pretty braindead about *which* `hasMany` relationship it would update. Before, it would just pick the first relationship it found with the same type as the child.
+Unfortunately, it was pretty braindead about *which* `hasMany` relationship it would update. Before, it would pick the first relationship it found with the same type as the child.
 
 Because it's reasonable for people to have multiple `belongsTo`/`hasMany`s for the same type, we added support for specifying an inverse:
 


### PR DESCRIPTION
## Description

Related issue: https://github.com/ember-learn/ember-blog/issues/852

I removed word exceptions that begin with the letter F-K. I read the surrounding text to understand context, then decided whether we can remove the word entirely, rephrase the text, or add an exception locally to the paragraph.

In some cases, I had to combine multiple lines into a single paragraph (i.e. new line changes). This was done so that the alex exception could take place without causing the Markdown-to-html conversion to accidentally break formatting.