### PR TITLE
fix(#854): add full url for logo

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -27,7 +27,7 @@ module.exports = function(environment) {
       title: 'Ember.js Blog',
       description: 'Official Blog for the Ember.js Open Source Project',
       paginate: true,
-      logo: "https://blog.emberjs.com/images/logos/e-icon.png",
+      logo: "/images/logos/e-icon.png",
       twitter: "emberjs",
     },
 
@@ -64,7 +64,8 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-    // here you can enable a production-specific feature
+    // Configure host for empress-blog
+    ENV.blog.host = 'https://blog.emberjs.com';
   }
 
   return ENV;

--- a/config/environment.js
+++ b/config/environment.js
@@ -27,7 +27,7 @@ module.exports = function(environment) {
       title: 'Ember.js Blog',
       description: 'Official Blog for the Ember.js Open Source Project',
       paginate: true,
-      logo: "/images/logos/e-icon.png",
+      logo: "https://blog.emberjs.com/images/logos/e-icon.png",
       twitter: "emberjs",
     },
 


### PR DESCRIPTION
## What it does
Twitter requires full URL iirc (LinkedIn and Facebook does not)
Moved from relative URL to `https://blog.emberjs.com/images/logos/e-icon.png` by configuring host in empress-blog (https://github.com/empress/empress-blog#configuring-your-host--enabling-rss)

## Related Issue(s)
Fix #854 

## Sources
https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary
https://cards-dev.twitter.com/validator