### PR TITLE
configure production host

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -65,6 +65,7 @@ module.exports = function(environment) {
 
   if (environment === 'production') {
     // here you can enable a production-specific feature
+    ENV.blog.host = 'https://blog.emberjs.com';
   }
 
   return ENV;

--- a/netlify.toml
+++ b/netlify.toml
@@ -35,3 +35,9 @@ from = "/tags/*"
 to = "/tag/:splat"
 status = 301
 force = false
+
+[[redirects]]
+from = "/feed.xml"
+to = "/rss.xml"
+status = 301
+force = false


### PR DESCRIPTION
## What it does
This configures the host in the production environment to be `https://blog.emberjs.com`. This should enable generation of the RSS feed as per: https://github.com/empress/empress-blog#configuring-your-host--enabling-rss

This also adds a redirect from `/feed.xml` to `/rss.xml` since the feed file name changes with empress-blog. This should enable feed readers that were previously configured to continue to find the feed.

## Related Issue(s)
n/a

## Sources
n/a
