### PR TITLE
update template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "ember-source": "~3.21.1",
         "ember-template-lint": "^2.11.0",
         "empress-blog": "^3.0.2",
-        "empress-blog-ember-template": "^1.1.0",
+        "empress-blog-ember-template": "^1.1.1",
         "eslint": "^7.8.0",
         "eslint-plugin-ember": "^8.13.0",
         "eslint-plugin-node": "^11.1.0",
@@ -16851,9 +16851,9 @@
       }
     },
     "node_modules/empress-blog-ember-template": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/empress-blog-ember-template/-/empress-blog-ember-template-1.1.0.tgz",
-      "integrity": "sha512-o0QSfyZrgiFzeQOb0T8+e5ZEYfDzlLIvzBYafNf5+c8FeuIu2qrkiLEbGItuswwXSVkDM+hxTQpggZlhYwWdUg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/empress-blog-ember-template/-/empress-blog-ember-template-1.1.1.tgz",
+      "integrity": "sha512-r6NoA8Cg0WpuGi55Yxf30/X3wrzfaRATDS/JHBPpg36Qj8R2KtHVHZgS29eMBpJxT58+8gH0T4c7zfgeoJ+llg==",
       "dev": true,
       "dependencies": {
         "@glimmer/component": "^1.0.1",
@@ -46864,9 +46864,9 @@
       }
     },
     "empress-blog-ember-template": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/empress-blog-ember-template/-/empress-blog-ember-template-1.1.0.tgz",
-      "integrity": "sha512-o0QSfyZrgiFzeQOb0T8+e5ZEYfDzlLIvzBYafNf5+c8FeuIu2qrkiLEbGItuswwXSVkDM+hxTQpggZlhYwWdUg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/empress-blog-ember-template/-/empress-blog-ember-template-1.1.1.tgz",
+      "integrity": "sha512-r6NoA8Cg0WpuGi55Yxf30/X3wrzfaRATDS/JHBPpg36Qj8R2KtHVHZgS29eMBpJxT58+8gH0T4c7zfgeoJ+llg==",
       "dev": true,
       "requires": {
         "@glimmer/component": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ember-source": "~3.21.1",
     "ember-template-lint": "^2.11.0",
     "empress-blog": "^3.0.2",
-    "empress-blog-ember-template": "^1.1.0",
+    "empress-blog-ember-template": "^1.1.1",
     "eslint": "^7.8.0",
     "eslint-plugin-ember": "^8.13.0",
     "eslint-plugin-node": "^11.1.0",


### PR DESCRIPTION
This is updating the empress-blog-ember-template in an effort to fix 2 issues with the comments: 

- comments not "updating" when you move between blog posts
- newer blog posts not getting the comments initialised properly

unfortunately we can't really test this before we go into production because of the nature of the domain restrictions in the Discourse comment system 😞  