### PR TITLE
Ember 3.25 Release

### DIFF
--- a/author/ricardo-mendes.md
+++ b/author/ricardo-mendes.md
@@ -2,7 +2,7 @@
 name: Ricardo Mendes
 image: ''
 cover: ''
-website: ''
-twitter: ''
+website: 'https://locks.wtf'
+twitter: 'locks'
 location: ''
 ---

--- a/content/ember-3-25-released.md
+++ b/content/ember-3-25-released.md
@@ -1,0 +1,116 @@
+---
+title: Ember 3.25 Released
+authors:
+  - the-crowd # replace with real authors from the author folder (add yourself if you're not there)
+date: 2021-02-18T00:00:00.000Z
+tags:
+  - releases
+  - '2021'
+  - version-3-x
+---
+
+Today the Ember project is releasing version 3.25 of Ember.js, Ember Data, and Ember CLI. <!-- Block start: Uncomment if an LTS candidate --><!--This release of Ember.js is an LTS (Long Term Support) candidate. LTS candidates prioritize stability over the addition of new features, and have an extended support schedule.--><!-- Block end -->
+
+This release kicks off the 3.26 beta cycle for all sub-projects. We encourage our community (especially addon authors) to help test these beta builds and report any bugs before they are published as a final release in six weeks' time. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
+
+You can read more about our general release process here:
+
+- [Release Dashboard](http://emberjs.com/releases/)
+- [The Ember Release Cycle](https://blog.emberjs.com/new-ember-release-process/)
+- [The Ember Project](https://blog.emberjs.com/ember-project-at-2-0/)
+- [Ember LTS Releases](https://blog.emberjs.com/announcing-embers-first-lts/)
+
+---
+
+## Ember.js
+
+Ember.js is the core framework for building ambitious web applications.
+
+### Changes in Ember.js 3.25
+
+Ember.js 3.25 is an incremental, backwards compatible release of Ember with bug fixes, performance improvements, and minor deprecations.
+
+#### Bug Fixes
+
+Ember.js 3.25 introduced 0 bug fixes.
+
+#### Features
+
+Ember.js 3.25 introduced 2 features.
+
+1. Feature description
+2. Feature description
+
+#### Deprecations
+
+Ember.js 3.25 introduced 0 deprecations.
+
+<!-- Block start: If there were no deprecations, remove this block -->
+Deprecations are added to Ember.js when an API will be removed at a later date. Each deprecation has an entry in the deprecation guide describing the migration path to a more stable API. Deprecated public APIs are not removed until a major release of the framework.
+
+Consider using the [ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow) addon if you would like to upgrade your application without immediately addressing deprecations.
+<!-- Block end -->
+
+For more details on changes in Ember.js 3.25, please review the [Ember.js 3.25.0 release page](https://github.com/emberjs/ember.js/releases/tag/v3.25.0).
+
+---
+
+## Ember Data
+
+Ember Data is the official data persistence library for Ember.js applications.
+
+### Changes in Ember Data 3.25
+
+#### Bug Fixes
+
+Ember Data 3.25 introduced 0 bug fixes.
+
+#### Features
+
+Ember Data 3.25 introduced 0 features.
+
+#### Deprecations
+
+Ember Data 3.25 introduced 0 deprecations.
+
+For more details on changes in Ember Data 3.25, please review the
+[Ember Data 3.25.0 release page](https://github.com/emberjs/data/releases/tag/v3.25.0).
+
+---
+
+## Ember CLI
+
+Ember CLI is the command line interface for managing and packaging Ember.js applications.
+
+### Upgrading Ember CLI
+
+You may upgrade Ember CLI using the `ember-cli-update` project:
+
+```bash
+npx ember-cli-update
+```
+
+This utility will help you to update your app or addon to the latest Ember CLI version. You will probably encounter merge conflicts, in which the default behavior is to let you resolve conflicts on your own. For more information on the `ember-cli-update` project, see [the GitHub README](https://github.com/ember-cli/ember-cli-update).
+
+While it is recommended to keep Ember CLI versions in sync with Ember and Ember Data, this is not required. After updating ember-cli, you can keep your current version(s) of Ember or Ember Data by editing `package.json` to revert the changes to the lines containing `ember-source` and `ember-data`.
+
+### Changes in Ember CLI 3.25
+
+#### Bug Fixes
+
+Ember CLI 3.25 introduced 0 bug fixes.
+
+#### Features
+
+Ember CLI 3.25 introduced 0 features.
+
+#### Deprecations
+
+Ember CLI 3.25 introduced 0 deprecations.
+
+For more details on the changes in Ember CLI 3.25 and detailed upgrade
+instructions, please review the [Ember CLI 3.25.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.25.0).
+
+## Thank You!
+
+As a community-driven open-source project with an ambitious scope, each of these releases serves as a reminder that the Ember project would not have been possible without your continued support. We are extremely grateful to our contributors for their efforts.

--- a/content/ember-3-25-released.md
+++ b/content/ember-3-25-released.md
@@ -104,7 +104,7 @@ But if `shoppingList` is empty, it renders the following instead:
 Named blocks are also useful if you want to ensure a certain structure to your HTML, but want to enable customization of the content.
 An example of this would be an `<Article>` component, as shown in the yieldable named blocks RFC ([#460](https://emberjs.github.io/rfcs/0460-yieldable-named-blocks.html#detailed-design)).
 
-You can find more information in the [Component API documentation](https://api.emberjs.com/ember/3.25/modules/@glimmer%2Fcomponent). More thorough documentation in the guides and tutorial will be released with the next version of Ember.
+You can find more information in the [Component API documentation](https://api.emberjs.com/ember/3.25/modules/@glimmer%2Fcomponent).
 
 #### Deprecations
 

--- a/content/ember-3-25-released.md
+++ b/content/ember-3-25-released.md
@@ -54,7 +54,7 @@ If these topics interest you, keep an eye on our [RFCs](https://github.com/ember
 This feature enables developers to yield distinct blocks from a component, unlocking powerful composition patterns for components.
 
 This feature is useful when you want to render different things depending on passed-in data.
-Let us implement a shopping cart that lists the items in it, or shows a message says that it is empty.
+Let us implement a shopping cart that lists the items in it, or shows a message that says it is empty.
 We will be using `{{gt}}` from [`ember-truth-helpers`](https://emberobserver.com/addons/ember-truth-helpers) to help implement this.
 
 First we write the component template:

--- a/content/ember-3-25-released.md
+++ b/content/ember-3-25-released.md
@@ -1,8 +1,8 @@
 ---
 title: Ember 3.25 Released
 authors:
-  - the-crowd # replace with real authors from the author folder (add yourself if you're not there)
-date: 2021-02-18T00:00:00.000Z
+  - ricardo-mendes # replace with real authors from the author folder (add yourself if you're not there)
+date: 2021-02-25T00:00:00.000Z
 tags:
   - releases
   - '2021'
@@ -32,24 +32,83 @@ Ember.js 3.25 is an incremental, backwards compatible release of Ember with bug 
 
 #### Bug Fixes
 
-Ember.js 3.25 introduced 0 bug fixes.
+Ember.js 3.25 contains several bug fixes, including:
+
+- Empty `hmtmlSafe` strings are now considered false. ([#18148](https://github.com/emberjs/ember.js/pull/18148))
+- Template locals no longer clobber component invocations of the same name. ([#19351](https://github.com/emberjs/ember.js/pull/19351))
+- Improved error message when invoking nested components, e.g. `<Foo:Bar />`. ([#19336](https://github.com/emberjs/ember.js/pull/19336))
+- Improved error messages and stack traces for `<LinkTo />`. ([#19342](https://github.com/emberjs/ember.js/pull/19342))
 
 #### Features
 
 Ember.js 3.25 introduced 2 features.
 
-1. Feature description
-2. Feature description
+1. Template strict mode ([#19302](https://github.com/emberjs/ember.js/pull/19302), [#19306](https://github.com/emberjs/ember.js/pull/19306), [#19319](https://github.com/emberjs/ember.js/pull/19319))
+
+While this feature won't have an impact for Ember developers quite yet, it is an important step towards allowing more experimental work in templates, like template imports and single-file components.
+
+If these topics interest you, keep an eye on our [RFCs](https://github.com/emberjs/rfcs) repository for activity and a chance to participate!
+
+1. Named blocks ([#19318](https://github.com/emberjs/ember.js/pull/19318))
+
+This feature enables developers to yield distinct blocks from a component, unlocking powerful composition patterns for components.
+
+This feature is useful when you want to render different things depending on passed-in data.
+Let us implement a shopping cart that lists the items in it, or shows a message says that it is empty.
+We will be using `{{gt}}` from [`ember-truth-helpers`](https://emberobserver.com/addons/ember-truth-helpers) to help implement this.
+
+First we write the component template:
+
+```handlebars
+// app/components/cart.hbs
+{{#if (gt @list.length 0)}}
+  <ul>
+    {{#each @list as |item|}}
+      <li>{{yield item}}</li>
+    {{/each}}
+  </ul>
+{{else}}
+  {{yield to="empty"}}
+{{/if}}
+```
+
+Which can be used like so:
+
+```handlebars
+<Cart @list={{this.shoppingList}}>
+  <:default as |listItem|>
+    <p>You have a {{listItem}}.</p>
+  </:default>
+  <:empty>
+    <p>Your cart is empty.</p>
+  </:empty>
+</Cart>
+```
+
+Then when `shoppingList` contains multiple elements, like `[ "apple", "pear", "banana" ]`, it renders the following:
+
+```handlebars
+<ul>
+  <li><p>apple</p</li>
+  <li><p>pear</p</li>
+  <li><p>banana</p</li>
+</ul>
+```
+
+But if `shoppingList` is empty, it renders the following instead:
+
+```handlebars
+<p>Your cart is empty.</p>
+```
+
+Named blocks are also useful if you want to ensure a certain structure to your HTML, but want to enable customization of the content.
+An example of this would be an `<Article>` component, as shown in the yieldable named blocks RFC ([#460](https://emberjs.github.io/rfcs/0460-yieldable-named-blocks.html#detailed-design)).
+
+You can find more information in the [Component API documentation](https://api.emberjs.com/ember/3.25/modules/@glimmer%2Fcomponent). More thorough documentation in the guides and tutorial will be released with the next version of Ember.
 
 #### Deprecations
 
 Ember.js 3.25 introduced 0 deprecations.
-
-<!-- Block start: If there were no deprecations, remove this block -->
-Deprecations are added to Ember.js when an API will be removed at a later date. Each deprecation has an entry in the deprecation guide describing the migration path to a more stable API. Deprecated public APIs are not removed until a major release of the framework.
-
-Consider using the [ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow) addon if you would like to upgrade your application without immediately addressing deprecations.
-<!-- Block end -->
 
 For more details on changes in Ember.js 3.25, please review the [Ember.js 3.25.0 release page](https://github.com/emberjs/ember.js/releases/tag/v3.25.0).
 
@@ -61,17 +120,7 @@ Ember Data is the official data persistence library for Ember.js applications.
 
 ### Changes in Ember Data 3.25
 
-#### Bug Fixes
-
-Ember Data 3.25 introduced 0 bug fixes.
-
-#### Features
-
-Ember Data 3.25 introduced 0 features.
-
-#### Deprecations
-
-Ember Data 3.25 introduced 0 deprecations.
+Apart from documentation fixes and internal cleanup of feature flags, there were no changes.
 
 For more details on changes in Ember Data 3.25, please review the
 [Ember Data 3.25.0 release page](https://github.com/emberjs/data/releases/tag/v3.25.0).
@@ -96,17 +145,7 @@ While it is recommended to keep Ember CLI versions in sync with Ember and Ember 
 
 ### Changes in Ember CLI 3.25
 
-#### Bug Fixes
-
-Ember CLI 3.25 introduced 0 bug fixes.
-
-#### Features
-
-Ember CLI 3.25 introduced 0 features.
-
-#### Deprecations
-
-Ember CLI 3.25 introduced 0 deprecations.
+Apart from updated dependencies in the app and addon blueprints, there were no changes.
 
 For more details on the changes in Ember CLI 3.25 and detailed upgrade
 instructions, please review the [Ember CLI 3.25.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.25.0).


### PR DESCRIPTION
[Preview](https://6037bc4d503bfb00076f2411--ember-blog.netlify.app/ember-3-25-released)

## Changelogs

### ember-source

- [#19326](https://github.com/emberjs/ember.js/pull/19326) / [#19387](https://github.com/emberjs/ember.js/pull/19387) [BUGFIX] Fix usage of `<LinkTo />` prior to routing (e.g. component rendering tests)
- [#19302](https://github.com/emberjs/ember.js/pull/19302) / [#19306](https://github.com/emberjs/ember.js/pull/19306) / [#19319](https://github.com/emberjs/ember.js/pull/19319) [FEATURE] Implement the [Handlebars Strict Mode RFC](https://github.com/emberjs/rfcs/blob/master/text/0496-handlebars-strict-mode.md).
- [#19318](https://github.com/emberjs/ember.js/pull/19318) [FEATURE] Implement the [Named Blocks RFC](https://github.com/emberjs/rfcs/blob/master/text/0460-yieldable-named-blocks.md).
- [#19320](https://github.com/emberjs/ember.js/pull/19320) / [#19317](https://github.com/emberjs/ember.js/pull/19317) / [#19297](https://github.com/emberjs/ember.js/pull/19297) / [#19293](https://github.com/emberjs/ember.js/pull/19293) / [#19278](https://github.com/emberjs/ember.js/pull/19278) / [#19275](https://github.com/emberjs/ember.js/pull/19275) / [#19363](https://github.com/emberjs/ember.js/pull/19363) Update rendering engine to `@glimmer/*` 0.74.2 for various features and bugfixes including ensuring `{{component.name}}` works with implicit this fallback
- [#18148](https://github.com/emberjs/ember.js/pull/18148) [BUGFIX] Fix empty `htmlSafe` string to be treated as falsy
- [#19365](https://github.com/emberjs/ember.js/pull/19365) [BUGFIX] Remove non-existing re-export from helper-addon blueprint
- [#19370](https://github.com/emberjs/ember.js/pull/19370) [BUGFIX] Update glimmer-vm to prevent errors for older inline precompilation
- [#19351](https://github.com/emberjs/ember.js/pull/19351) [BUGFIX] Ensure locals do not clobber components of the same name
- [#19336](https://github.com/emberjs/ember.js/pull/19336) [BUGFIX] Ensure Component Lookup Is Well Formed
- [#19338](https://github.com/emberjs/ember.js/pull/19338) [BUGFIX] Add missing `deprecate` options (`for` + `since`)
- [#19342](https://github.com/emberjs/ember.js/pull/19342) [BUGFIX] Fix misleading LinkTo error message

### ember-data

- [#7394](https://github.com/emberjs/data/pull/7394) [Cleanup]: Remove RECORD_ARRAY_MANAGER_IDENTIFIERS (#7394)
- [#7393](https://github.com/emberjs/data/pull/7393) [Cleanup]: Remove FULL_LINKS_ON_RELATIONSHIPS (#7393)
- [#7292](https://github.com/emberjs/data/pull/7292) [DOC model] convert api examples to native classes/Octane (#7292)
- [#7399](https://github.com/emberjs/data/pull/7399) Fix deprecation URLs (#7399)
- [623145d0](https://github.com/emberjs/data/commit/623145d0009d683a50468ba9961431ae76ae6df6) [DOC adapter] fix parent class invocation syntax (#7405)

### ember-cli

- [#9437](https://github.com/ember-cli/ember-cli/pull/9437) Add Prettier files to ".npmignore" file in addon blueprint [@bertdeblock](https://github.com/bertdeblock)
- [#9436](https://github.com/ember-cli/ember-cli/pull/9436) Enable Embroider test scenario for addons [@thoov](https://github.com/thoov)
- [#9435](https://github.com/ember-cli/ember-cli/pull/9435) Use "lint:fix" script in app and addon README files [@bertdeblock](https://github.com/bertdeblock)
- [#9451](https://github.com/ember-cli/ember-cli/pull/9451) update blueprint deps [@kellyselden](https://github.com/kellyselden)