### PR TITLE
Ember 3.26 Release

### DIFF
--- a/content/ember-3-26-released.md
+++ b/content/ember-3-26-released.md
@@ -45,7 +45,13 @@ Ember.js 3.26 introduced 0 features.
 
 #### Deprecations
 
-Ember.js 3.26 introduced 11 deprecations.
+Ember.js 3.26 introduced 11 deprecations. To learn more how to update your code, please check the provided link to the Deprecations Guide.
+
+1. Component managers that use the `v3.4` capabilities should update to the most recent component capabilities available, which is currently `v3.13`. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_manager-capabilities-components-3-4), [#19373](https://github.com/emberjs/ember.js/pull/19373))
+1. Modifier managers that use the `v3.13` capabilities should update to the most recent modifier capabilities available, which is currently `v3.22. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_manager-capabilities-modifiers-3-13), [#19373](https://github.com/emberjs/ember.js/pull/19373))
+1. Passing `classBinding` and `classNameBindings` as arguments has been deprecated. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_class-binding-and-class-name-bindings-in-templates), [#19375](https://github.com/emberjs/ember.js/pull/19375))
+1. Accessing named arguments via `{{attrs}}` has been deprecated. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_attrs-arg-access), [#19375](https://github.com/emberjs/ember.js/pull/19375))
+1. Array observers have been deprecated. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_array-observers), [#19381](https://github.com/emberjs/ember.js/pull/19381))
 
 Deprecations are added to Ember.js when an API will be removed at a later date. Each deprecation has an entry in the deprecation guide describing the migration path to a more stable API. Deprecated public APIs are not removed until a major release of the framework.
 

--- a/content/ember-3-26-released.md
+++ b/content/ember-3-26-released.md
@@ -1,0 +1,97 @@
+---
+title: Ember 3.26 Released
+authors:
+  -  # replace with real authors from the author folder (add yourself if you're not there)
+date: 2021-03-31T00:00:00.000Z
+tags:
+  - releases
+  - '2021'
+  - version-3-x
+---
+
+Today the Ember project is releasing Version 3.26 of Ember.js, Ember Data, and Ember CLI. This release kicks off the 3.5 beta cycle for all sub-projects. We encourage our community (especially addon authors) to help test these beta builds and report any bugs before they are published as a final release in six weeks' time. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
+
+You can read more about our general release process here:
+
+- [Release Dashboard](http://emberjs.com/releases/)
+- [The Ember Release Cycle](http://emberjs.com/blog/2013/09/06/new-ember-release-process.html)
+- [The Ember Project](http://emberjs.com/blog/2015/06/16/ember-project-at-2-0.html)
+- [Ember LTS Releases](http://emberjs.com/blog/2016/02/25/announcing-embers-first-lts.html)
+
+---
+
+## Ember.js
+
+Ember.js is the core framework for building ambitious web applications.
+
+### Changes in Ember.js 3.26
+
+Ember.js 3.26 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There is COUNT (#) new feature, COUNT (#) deprecations, and COUNT (#) bugfixes in this version.
+
+#### New Features
+
+First new feature (1 of 2)
+
+Second new feature (2 of 2)
+
+#### Deprecations
+
+Deprecations are added to Ember.js when an API will be removed at a later date. Each deprecation has an entry in the deprecation guide describing the migration path to a more stable API. Deprecated public APIs are not removed until a major release of the framework.
+
+Consider using the [ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow) addon if you would like to upgrade your application without immediately addressing deprecations.
+
+For more details on changes in Ember.js 3.26, please review the [Ember.js 3.26.0 release page](https://github.com/emberjs/ember.js/releases/tag/v3.26.0).
+
+---
+
+## Ember Data
+
+Ember Data is the official data persistence library for Ember.js applications.
+
+### Changes in Ember Data 3.26
+
+#### New Features
+
+No new features introduced in Ember Data 3.26.
+
+#### Deprecations
+
+No new deprecations introduced in Ember Data 3.26.
+
+For more details on changes in Ember Data 3.26, please review the
+[Ember Data 3.26.0 release page](https://github.com/emberjs/data/releases/tag/v3.26.0).
+
+---
+
+## Ember CLI
+
+Ember CLI is the command line interface for managing and packaging Ember.js applications.
+
+### Upgrading Ember CLI
+
+<!--alex ignore easy-->
+You may upgrade Ember CLI easily using the ember-cli-update project:
+
+```bash
+npm install -g ember-cli-update
+ember-cli-update
+```
+
+This utility will help you to update your app or add-on to the latest Ember CLI Version. You will probably encounter merge conflicts, in which the default behavior is to let you resolve conflicts on your own. For more information on the `ember-cli-update` project, see [the github README](https://github.com/ember-cli/ember-cli-update).
+
+While it is recommended to keep Ember CLI Versions in sync with Ember and Ember Data, this is not required. After updating ember-cli, you can keep your current 3.26sion(s) of Ember or Ember Data by editing `package.json` to revert the changes to the lines containing `ember-source` and `ember-data`.
+
+### Changes in Ember CLI 3.26
+
+#### New Features (X)
+
+#### Deprecations (X)
+
+---
+
+For more details on the changes in Ember CLI 3.26 and detailed upgrade
+instructions, please review the [Ember CLI  3.26.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.26.0).
+
+## Thank You!
+
+As a community-driven open-source project with an ambitious scope, each of these releases serve as a reminder that the Ember project would not have been possible without your continued support. We are extremely grateful to our contributors for their efforts.

--- a/content/ember-3-26-released.md
+++ b/content/ember-3-26-released.md
@@ -9,14 +9,16 @@ tags:
   - version-3-x
 ---
 
-Today the Ember project is releasing Version 3.26 of Ember.js, Ember Data, and Ember CLI. This release kicks off the 3.5 beta cycle for all sub-projects. We encourage our community (especially addon authors) to help test these beta builds and report any bugs before they are published as a final release in six weeks' time. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
+Today the Ember project is releasing version VER of Ember.js, Ember Data, and Ember CLI. <!-- Block start: Uncomment if an LTS candidate --><!--This release of Ember.js is an LTS (Long Term Support) candidate. LTS candidates prioritize stability over the addition of new features, and have an extended support schedule.--><!-- Block end -->
+
+This release kicks off the VER+0.1 beta cycle for all sub-projects. We encourage our community (especially addon authors) to help test these beta builds and report any bugs before they are published as a final release in six weeks' time. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
 
 You can read more about our general release process here:
 
 - [Release Dashboard](http://emberjs.com/releases/)
-- [The Ember Release Cycle](http://emberjs.com/blog/2013/09/06/new-ember-release-process.html)
-- [The Ember Project](http://emberjs.com/blog/2015/06/16/ember-project-at-2-0.html)
-- [Ember LTS Releases](http://emberjs.com/blog/2016/02/25/announcing-embers-first-lts.html)
+- [The Ember Release Cycle](https://blog.emberjs.com/new-ember-release-process/)
+- [The Ember Project](https://blog.emberjs.com/ember-project-at-2-0/)
+- [Ember LTS Releases](https://blog.emberjs.com/announcing-embers-first-lts/)
 
 ---
 
@@ -24,23 +26,32 @@ You can read more about our general release process here:
 
 Ember.js is the core framework for building ambitious web applications.
 
-### Changes in Ember.js 3.26
+### Changes in Ember.js VER
 
-Ember.js 3.26 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There is COUNT (#) new feature, COUNT (#) deprecations, and COUNT (#) bugfixes in this version.
+Ember.js VER is an incremental, backwards compatible release of Ember with bug fixes, performance improvements, and minor deprecations.
 
-#### New Features
+#### Bug Fixes
 
-First new feature (1 of 2)
+Ember.js VER introduced 0 bug fixes.
 
-Second new feature (2 of 2)
+#### Features
+
+Ember.js VER introduced 2 features.
+
+1. Feature description
+2. Feature description
 
 #### Deprecations
 
+Ember.js VER introduced 0 deprecations.
+
+<!-- Block start: If there were no deprecations, remove this block -->
 Deprecations are added to Ember.js when an API will be removed at a later date. Each deprecation has an entry in the deprecation guide describing the migration path to a more stable API. Deprecated public APIs are not removed until a major release of the framework.
 
 Consider using the [ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow) addon if you would like to upgrade your application without immediately addressing deprecations.
+<!-- Block end -->
 
-For more details on changes in Ember.js 3.26, please review the [Ember.js 3.26.0 release page](https://github.com/emberjs/ember.js/releases/tag/v3.26.0).
+For more details on changes in Ember.js VER, please review the [Ember.js VER.0 release page](https://github.com/emberjs/ember.js/releases/tag/vVER.0).
 
 ---
 
@@ -48,18 +59,22 @@ For more details on changes in Ember.js 3.26, please review the [Ember.js 3.26.0
 
 Ember Data is the official data persistence library for Ember.js applications.
 
-### Changes in Ember Data 3.26
+### Changes in Ember Data VER
 
-#### New Features
+#### Bug Fixes
 
-No new features introduced in Ember Data 3.26.
+Ember Data VER introduced 0 bug fixes.
+
+#### Features
+
+Ember Data VER introduced 0 features.
 
 #### Deprecations
 
-No new deprecations introduced in Ember Data 3.26.
+Ember Data VER introduced 0 deprecations.
 
-For more details on changes in Ember Data 3.26, please review the
-[Ember Data 3.26.0 release page](https://github.com/emberjs/data/releases/tag/v3.26.0).
+For more details on changes in Ember Data VER, please review the
+[Ember Data VER.0 release page](https://github.com/emberjs/data/releases/tag/vVER.0).
 
 ---
 
@@ -69,29 +84,33 @@ Ember CLI is the command line interface for managing and packaging Ember.js appl
 
 ### Upgrading Ember CLI
 
-<!--alex ignore easy-->
-You may upgrade Ember CLI easily using the ember-cli-update project:
+You may upgrade Ember CLI using the `ember-cli-update` project:
 
 ```bash
-npm install -g ember-cli-update
-ember-cli-update
+npx ember-cli-update
 ```
 
-This utility will help you to update your app or add-on to the latest Ember CLI Version. You will probably encounter merge conflicts, in which the default behavior is to let you resolve conflicts on your own. For more information on the `ember-cli-update` project, see [the github README](https://github.com/ember-cli/ember-cli-update).
+This utility will help you to update your app or addon to the latest Ember CLI version. You will probably encounter merge conflicts, in which the default behavior is to let you resolve conflicts on your own. For more information on the `ember-cli-update` project, see [the GitHub README](https://github.com/ember-cli/ember-cli-update).
 
-While it is recommended to keep Ember CLI Versions in sync with Ember and Ember Data, this is not required. After updating ember-cli, you can keep your current 3.26sion(s) of Ember or Ember Data by editing `package.json` to revert the changes to the lines containing `ember-source` and `ember-data`.
+While it is recommended to keep Ember CLI versions in sync with Ember and Ember Data, this is not required. After updating ember-cli, you can keep your current version(s) of Ember or Ember Data by editing `package.json` to revert the changes to the lines containing `ember-source` and `ember-data`.
 
-### Changes in Ember CLI 3.26
+### Changes in Ember CLI VER
 
-#### New Features (X)
+#### Bug Fixes
 
-#### Deprecations (X)
+Ember CLI VER introduced 0 bug fixes.
 
----
+#### Features
 
-For more details on the changes in Ember CLI 3.26 and detailed upgrade
-instructions, please review the [Ember CLI  3.26.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.26.0).
+Ember CLI VER introduced 0 features.
+
+#### Deprecations
+
+Ember CLI VER introduced 0 deprecations.
+
+For more details on the changes in Ember CLI VER and detailed upgrade
+instructions, please review the [Ember CLI VER.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/vVER.0).
 
 ## Thank You!
 
-As a community-driven open-source project with an ambitious scope, each of these releases serve as a reminder that the Ember project would not have been possible without your continued support. We are extremely grateful to our contributors for their efforts.
+As a community-driven open-source project with an ambitious scope, each of these releases serves as a reminder that the Ember project would not have been possible without your continued support. We are extremely grateful to our contributors for their efforts.

--- a/content/ember-3-26-released.md
+++ b/content/ember-3-26-released.md
@@ -62,6 +62,7 @@ Ember.js 3.26 introduced several deprecations in preparation for v4.0 release. T
         ```json
         {
           "application-template-wrapper": false,
+          "jquery-integration": false,
           "template-only-glimmer-components": true
         }
         ```

--- a/content/ember-3-26-released.md
+++ b/content/ember-3-26-released.md
@@ -56,7 +56,7 @@ Ember.js 3.26 introduced several deprecations in preparation for v4.0 release. T
     In preparation for v4.0 release, developers are encouraged to update their app to Ember Octane by following these steps:
 
     - In `config/optional-features.json`, update the feature flags for Octane.
-    
+
         ```json
         {
           "application-template-wrapper": false,

--- a/content/ember-3-26-released.md
+++ b/content/ember-3-26-released.md
@@ -9,9 +9,9 @@ tags:
   - version-3-x
 ---
 
-Today the Ember project is releasing version VER of Ember.js, Ember Data, and Ember CLI. <!-- Block start: Uncomment if an LTS candidate --><!--This release of Ember.js is an LTS (Long Term Support) candidate. LTS candidates prioritize stability over the addition of new features, and have an extended support schedule.--><!-- Block end -->
+Today the Ember project is releasing version 3.26 of Ember.js, Ember Data, and Ember CLI.
 
-This release kicks off the VER+0.1 beta cycle for all sub-projects. We encourage our community (especially addon authors) to help test these beta builds and report any bugs before they are published as a final release in six weeks' time. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
+This release kicks off the 3.27 beta cycle for all sub-projects. We encourage our community (especially addon authors) to help test these beta builds and report any bugs before they are published as a final release in six weeks' time. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
 
 You can read more about our general release process here:
 
@@ -26,24 +26,24 @@ You can read more about our general release process here:
 
 Ember.js is the core framework for building ambitious web applications.
 
-### Changes in Ember.js VER
+### Changes in Ember.js 3.26
 
-Ember.js VER is an incremental, backwards compatible release of Ember with bug fixes, performance improvements, and minor deprecations.
+Ember.js 3.26 is an incremental, backwards compatible release of Ember with bug fixes, performance improvements, and minor deprecations.
 
 #### Bug Fixes
 
-Ember.js VER introduced 0 bug fixes.
+Ember.js 3.26 introduced 0 bug fixes.
 
 #### Features
 
-Ember.js VER introduced 2 features.
+Ember.js 3.26 introduced 2 features.
 
 1. Feature description
 2. Feature description
 
 #### Deprecations
 
-Ember.js VER introduced 0 deprecations.
+Ember.js 3.26 introduced 0 deprecations.
 
 <!-- Block start: If there were no deprecations, remove this block -->
 Deprecations are added to Ember.js when an API will be removed at a later date. Each deprecation has an entry in the deprecation guide describing the migration path to a more stable API. Deprecated public APIs are not removed until a major release of the framework.
@@ -51,7 +51,7 @@ Deprecations are added to Ember.js when an API will be removed at a later date. 
 Consider using the [ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow) addon if you would like to upgrade your application without immediately addressing deprecations.
 <!-- Block end -->
 
-For more details on changes in Ember.js VER, please review the [Ember.js VER.0 release page](https://github.com/emberjs/ember.js/releases/tag/vVER.0).
+For more details on changes in Ember.js 3.26, please review the [Ember.js 3.26.0 release page](https://github.com/emberjs/ember.js/releases/tag/v3.26.0).
 
 ---
 
@@ -59,22 +59,22 @@ For more details on changes in Ember.js VER, please review the [Ember.js VER.0 r
 
 Ember Data is the official data persistence library for Ember.js applications.
 
-### Changes in Ember Data VER
+### Changes in Ember Data 3.26
 
 #### Bug Fixes
 
-Ember Data VER introduced 0 bug fixes.
+Ember Data 3.26 introduced 0 bug fixes.
 
 #### Features
 
-Ember Data VER introduced 0 features.
+Ember Data 3.26 introduced 0 features.
 
 #### Deprecations
 
-Ember Data VER introduced 0 deprecations.
+Ember Data 3.26 introduced 0 deprecations.
 
-For more details on changes in Ember Data VER, please review the
-[Ember Data VER.0 release page](https://github.com/emberjs/data/releases/tag/vVER.0).
+For more details on changes in Ember Data 3.26, please review the
+[Ember Data 3.26.0 release page](https://github.com/emberjs/data/releases/tag/v3.26.0).
 
 ---
 
@@ -94,22 +94,22 @@ This utility will help you to update your app or addon to the latest Ember CLI v
 
 While it is recommended to keep Ember CLI versions in sync with Ember and Ember Data, this is not required. After updating ember-cli, you can keep your current version(s) of Ember or Ember Data by editing `package.json` to revert the changes to the lines containing `ember-source` and `ember-data`.
 
-### Changes in Ember CLI VER
+### Changes in Ember CLI 3.26
 
 #### Bug Fixes
 
-Ember CLI VER introduced 0 bug fixes.
+Ember CLI 3.26 introduced 0 bug fixes.
 
 #### Features
 
-Ember CLI VER introduced 0 features.
+Ember CLI 3.26 introduced 0 features.
 
 #### Deprecations
 
-Ember CLI VER introduced 0 deprecations.
+Ember CLI 3.26 introduced 0 deprecations.
 
-For more details on the changes in Ember CLI VER and detailed upgrade
-instructions, please review the [Ember CLI VER.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/vVER.0).
+For more details on the changes in Ember CLI 3.26 and detailed upgrade
+instructions, please review the [Ember CLI 3.26.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.26.0).
 
 ## Thank You!
 

--- a/content/ember-3-26-released.md
+++ b/content/ember-3-26-released.md
@@ -113,7 +113,7 @@ Ember CLI 3.26 introduced 2 bug fixes.
 
 Ember CLI 3.26 introduced 1 feature.
 
-1. `ember-try` test scenarios for `embroider-safe` and `embroider-optimized` for addons are now enabled using [@embroider/test-setup](https://github.com/embroider-build/embroider/tree/master/packages/test-setup) allowing Embroider compatibility testing for addons test matrix.
+1. `ember-try` test scenarios for `embroider-safe` and `embroider-optimized` for addons are now enabled using [@embroider/test-setup](https://github.com/embroider-build/embroider/tree/master/packages/test-setup) allowing Embroider compatibility testing for addons test matrix ([#9436](https://github.com/ember-cli/ember-cli/pull/9436)).
 
 #### Deprecations
 

--- a/content/ember-3-26-released.md
+++ b/content/ember-3-26-released.md
@@ -107,11 +107,13 @@ While it is recommended to keep Ember CLI versions in sync with Ember and Ember 
 Ember CLI 3.26 introduced 2 bug fixes.
 
 1. Issue a better error message for add-on's missing an entry point. ([#9473](https://github.com/ember-cli/ember-cli/pull/9473)); and
-2. Add Prettier files to ".npmignore" file in addon blueprint ([#9437](https://github.com/ember-cli/ember-cli/pull/9437)).
+2. Add Prettier files to `.npmignore` file in addon blueprint ([#9437](https://github.com/ember-cli/ember-cli/pull/9437)).
 
 #### Features
 
-Ember CLI 3.26 introduced 0 features.
+Ember CLI 3.26 introduced 1 feature.
+
+1. `ember-try` test scenarios for `embroider-safe` and `embroider-optimized` for addons are now enabled using [@embroider/test-setup](https://github.com/embroider-build/embroider/tree/master/packages/test-setup) allowing Embroider compatibility testing for addons test matrix.
 
 #### Deprecations
 

--- a/content/ember-3-26-released.md
+++ b/content/ember-3-26-released.md
@@ -45,7 +45,36 @@ Ember.js 3.26 introduced 0 features.
 
 #### Deprecations
 
-Ember.js 3.26 introduced 11 deprecations. To learn more how to update your code, please check the provided link to the Deprecations Guide.
+Ember.js 3.26 introduced several deprecations in preparation for v4.0 release. To learn more how to update your code, please check the provided link to the Deprecations Guide.
+
+1. The `{{with}}` helper has been deprecated, in favor of using `{{let}}`. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_ember-glimmer-with-syntax), [#19346](https://github.com/emberjs/ember.js/pull/19346))
+1. Implicit injection has been deprecated. In particular, the `store` service from Ember Data must be explicitly injected into controllers and routes if they refer to `this.store`. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_implicit-injections), [#19358](https://github.com/emberjs/ember.js/pull/19358))
+1. Browser support of Internet Explorer 11 has been deprecated. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_3-0-browser-support-policy), [#19359](https://github.com/emberjs/ember.js/pull/19359))
+1. Property fallback for implicit `this` has been deprecated. Please review the templates in your app and write `this.` when it is appropriate, e.g. change `{{localProperty}}` to `{{this.localProperty}}`. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_this-property-fallback), [#19371](https://github.com/emberjs/ember.js/pull/19371))
+1. **Ember Classic has been deprecated.** ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_editions-classic), [#19372](https://github.com/emberjs/ember.js/pull/19372))
+
+    In preparation for v4.0 release, developers are encouraged to update their app to Ember Octane by following these steps:
+
+    - In `config/optional-features.json`, update the feature flags for Octane.
+    
+        ```json
+        {
+          "application-template-wrapper": false,
+          "template-only-glimmer-components": true
+        }
+        ```
+
+    - Specify the Octane edition in `package.json`.
+
+        ```json
+        {
+          "ember": {
+            "edition": "octane"
+          }
+        }
+        ```
+
+    - Check the [official upgrade guide](https://guides.emberjs.com/release/upgrading/current-edition/) and seek help in the `#help` channel on [Ember Discord](https://discord.gg/emberjs).
 
 1. Component managers that use the `v3.4` capabilities should update to the most recent component capabilities available, which is currently `v3.13`. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_manager-capabilities-components-3-4), [#19373](https://github.com/emberjs/ember.js/pull/19373))
 1. Modifier managers that use the `v3.13` capabilities should update to the most recent modifier capabilities available, which is currently `v3.22. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_manager-capabilities-modifiers-3-13), [#19373](https://github.com/emberjs/ember.js/pull/19373))

--- a/content/ember-3-26-released.md
+++ b/content/ember-3-26-released.md
@@ -104,7 +104,10 @@ While it is recommended to keep Ember CLI versions in sync with Ember and Ember 
 
 #### Bug Fixes
 
-Ember CLI 3.26 introduced 0 bug fixes.
+Ember CLI 3.26 introduced 2 bug fixes.
+
+1. Issue a better error message for add-on's missing an entry point. ([#9473](https://github.com/ember-cli/ember-cli/pull/9473)); and
+2. Add Prettier files to ".npmignore" file in addon blueprint ([#9437](https://github.com/ember-cli/ember-cli/pull/9437)).
 
 #### Features
 

--- a/content/ember-3-26-released.md
+++ b/content/ember-3-26-released.md
@@ -47,6 +47,8 @@ Ember.js 3.26 introduced 0 features.
 
 Ember.js 3.26 introduced several deprecations in preparation for v4.0 release. To learn more how to update your code, please check the provided link to the Deprecations Guide.
 
+1. Transition methods of controllers and routes have been deprecated. Inject the `router` service and use the service's methods instead. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_routing-transition-methods), [#19255](https://github.com/emberjs/ember.js/pull/19255))
+1. Invoking the `<LinkTo>` component with positional arguments has been deprecated. Please provide named arguments such as `@route`, `@model`, `@models`, and `@query`. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_ember-glimmer-link-to-positional-arguments), [#19345](https://github.com/emberjs/ember.js/pull/19345))
 1. The `{{with}}` helper has been deprecated, in favor of using `{{let}}`. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_ember-glimmer-with-syntax), [#19346](https://github.com/emberjs/ember.js/pull/19346))
 1. Implicit injection has been deprecated. In particular, the `store` service from Ember Data must be explicitly injected into controllers and routes if they refer to `this.store`. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_implicit-injections), [#19358](https://github.com/emberjs/ember.js/pull/19358))
 1. Browser support of Internet Explorer 11 has been deprecated. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_3-0-browser-support-policy), [#19359](https://github.com/emberjs/ember.js/pull/19359))
@@ -78,6 +80,7 @@ Ember.js 3.26 introduced several deprecations in preparation for v4.0 release. T
 
 1. Component managers that use the `v3.4` capabilities should update to the most recent component capabilities available, which is currently `v3.13`. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_manager-capabilities-components-3-4), [#19373](https://github.com/emberjs/ember.js/pull/19373))
 1. Modifier managers that use the `v3.13` capabilities should update to the most recent modifier capabilities available, which is currently `v3.22. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_manager-capabilities-modifiers-3-13), [#19373](https://github.com/emberjs/ember.js/pull/19373))
+1. The `{{hasBlock}}` and `{{hasBlockParams}}` properties have been deprecated. Use `{{has-block}}` and `{{has-block-params}}` helpers instead. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_has-block-and-has-block-params), [#19374](https://github.com/emberjs/ember.js/pull/19374))
 1. Passing `classBinding` and `classNameBindings` as arguments has been deprecated. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_class-binding-and-class-name-bindings-in-templates), [#19375](https://github.com/emberjs/ember.js/pull/19375))
 1. Accessing named arguments via `{{attrs}}` has been deprecated. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_attrs-arg-access), [#19375](https://github.com/emberjs/ember.js/pull/19375))
 1. Array observers have been deprecated. ([Deprecations Guide](https://deprecations.emberjs.com/v3.x#toc_array-observers), [#19381](https://github.com/emberjs/ember.js/pull/19381))

--- a/content/ember-3-26-released.md
+++ b/content/ember-3-26-released.md
@@ -3,7 +3,7 @@ title: Ember 3.26 Released
 authors:
   - isaac-lee
   - jared-galanis
-date: 2021-03-31T00:00:00.000Z
+date: 2021-04-12T00:00:00.000Z
 tags:
   - releases
   - '2021'

--- a/content/ember-3-26-released.md
+++ b/content/ember-3-26-released.md
@@ -1,7 +1,8 @@
 ---
 title: Ember 3.26 Released
 authors:
-  -  # replace with real authors from the author folder (add yourself if you're not there)
+  - isaac-lee
+  - jared-galanis
 date: 2021-03-31T00:00:00.000Z
 tags:
   - releases

--- a/content/ember-3-26-released.md
+++ b/content/ember-3-26-released.md
@@ -32,24 +32,23 @@ Ember.js 3.26 is an incremental, backwards compatible release of Ember with bug 
 
 #### Bug Fixes
 
-Ember.js 3.26 introduced 0 bug fixes.
+Ember.js 3.26 introduced 5 bug fixes. Here are a few notable ones:
+
+1. The Ember router and the `router` service have been updated so that an infinite recursion does not occur when the `router` service is injected into `app/router.js`. ([#19405](https://github.com/emberjs/ember.js/pull/19405))
+2. You can pass to an observer a dependent key whose name includes a colon. ([#19343](https://github.com/emberjs/ember.js/issues/19343))
+3. The Glimmer VM has been updated to prevent eagerly consuming arguments during modifier destruction. ([#19469](https://github.com/emberjs/ember.js/pull/19469))
 
 #### Features
 
-Ember.js 3.26 introduced 2 features.
-
-1. Feature description
-2. Feature description
+Ember.js 3.26 introduced 0 features.
 
 #### Deprecations
 
-Ember.js 3.26 introduced 0 deprecations.
+Ember.js 3.26 introduced 11 deprecations.
 
-<!-- Block start: If there were no deprecations, remove this block -->
 Deprecations are added to Ember.js when an API will be removed at a later date. Each deprecation has an entry in the deprecation guide describing the migration path to a more stable API. Deprecated public APIs are not removed until a major release of the framework.
 
 Consider using the [ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow) addon if you would like to upgrade your application without immediately addressing deprecations.
-<!-- Block end -->
 
 For more details on changes in Ember.js 3.26, please review the [Ember.js 3.26.0 release page](https://github.com/emberjs/ember.js/releases/tag/v3.26.0).
 


### PR DESCRIPTION
## Changelogs

### ember-source

- [x] [#19255](https://github.com/emberjs/ember.js/pull/19255) [DEPRECATION] Deprecate transition methods of controller and route per [RFC #674](https://github.com/emberjs/rfcs/blob/master/text/0674-deprecate-transition-methods-of-controller-and-route.md).
- [x] [#19345](https://github.com/emberjs/ember.js/pull/19345) [DEPRECATION] Deprecate `<LinkTo>` positional arguments per [RFC #698](https://github.com/emberjs/rfcs/blob/master/text/0698-deprecate-link-to-positional-arguments.md).
- [x] [#19346](https://github.com/emberjs/ember.js/pull/19346) [DEPRECATION] Deprecate `{{#with}}` per [RFC #445](https://github.com/emberjs/rfcs/blob/master/text/0445-deprecate-with.md)
- [x] [#19358](https://github.com/emberjs/ember.js/pull/19358) [DEPRECATION] Deprecate implicit injections per [RFC #680](https://github.com/emberjs/rfcs/blob/master/text/0680-implicit-injection-deprecation.md)
- [x] [#19359](https://github.com/emberjs/ember.js/pull/19359) [DEPRECATION] Deprecates old browser support policy per [RFC #685 New Browser Support Policy](https://github.com/emberjs/rfcs/blob/master/text/0685-new-browser-support-policy.md).
- [x] [#19371](https://github.com/emberjs/ember.js/pull/19371) [DEPRECATION] Deprecate implicit `this` property lookup fallback per [RFC #308](https://github.com/emberjs/rfcs/blob/master/text/0308-deprecate-property-lookup-fallback.md)
- [x] [#19372](https://github.com/emberjs/ember.js/pull/19372) [DEPRECATION] Adds deprecations for Classic edition and optional features per [RFC #704](https://github.com/emberjs/rfcs/blob/master/text/0704-deprecate-octane-optional-features.md) and [RFC #705](https://github.com/emberjs/rfcs/blob/master/text/0705-deprecate-jquery-optional-feature.md).
- [x] [#19373](https://github.com/emberjs/ember.js/pull/19373) [DEPRECATION] Deprecate old manager capabilities per [RFC #686](https://github.com/emberjs/rfcs/blob/master/text/0686-deprecate-old-manager-capabilities-versions.md)
- [x] [#19374](https://github.com/emberjs/ember.js/pull/19374) [DEPRECATION] Deprecate `hasBlock` and `hasBlockParams` per [RFC #689](https://github.com/emberjs/rfcs/blob/master/text/0689-deprecate-has-block.md).
- [x] [#19375](https://github.com/emberjs/ember.js/pull/19375) [DEPRECATION] Deprecate old class binding syntax and {{attrs}} per [RFC #691](https://github.com/emberjs/rfcs/blob/master/text/0691-deprecate-class-binding-and-class-name-bindings.md) and [RFC #690](https://github.com/emberjs/rfcs/blob/master/text/0690-deprecate-attrs-in-templates.md).
- [x] [#19381](https://github.com/emberjs/ember.js/pull/19381) [DEPRECATION] Deprecate Array Observers per [RFC #692](https://github.com/emberjs/rfcs/blob/master/text/0692-deprecate-array-observers.md).
- [ ] ~[#19379](https://github.com/emberjs/ember.js/pull/19379) [CLEANUP] Refactor DataAdapter to not use observers or array observers~
- [ ] ~[#19378](https://github.com/emberjs/ember.js/pull/19378) [BUGFIX] Fix typo in template-only-glimmer-components feature detection~
- [ ] ~[#19298](https://github.com/emberjs/ember.js/pull/19298) [BUGFIX] Route serialize did not extract param off proxy~
- [x] [#19469](https://github.com/emberjs/ember.js/pull/19469) [BUGFIX] Prevent eager argument consumption on modifier destruction
- [x] [#19405](https://github.com/emberjs/ember.js/pull/19405) [BUGFIX] Avoid instantiation errors when `app/router.js` injects the router service.
- [x] [#19436](https://github.com/emberjs/ember.js/pull/19436) [BUGFIX] Support observer keys with colons

### ember-data

- [ ] ~~[#7435](https://github.com/emberjs/data/pull/7435) [Test]: fix for DataWrapper refactor in emberjs (#7435)~~
- [ ] ~~[#7416](https://github.com/emberjs/data/pull/7416) [Deps]: bump ember packages (#7416)~~
- [ ] ~~[#7358](https://github.com/emberjs/data/pull/7358) [Chore]: TypeScript adapters (#7358)~~

### ember-cli

- [x] [#9473](https://github.com/ember-cli/ember-cli/pull/9473) Issue a better error message for add-on's missing an entry point (e.g. invalid `ember-addon.main` path)
- [x] [#9437](https://github.com/ember-cli/ember-cli/pull/9437) Add Prettier files to ".npmignore" file in addon blueprint
- [x] [#9436](https://github.com/ember-cli/ember-cli/pull/9436) Enable Embroider test scenario for addons
- [ ] ~~[#9435](https://github.com/ember-cli/ember-cli/pull/9435) Use "lint:fix" script in app and addon README files~~ 
- [ ] ~~[#9451](https://github.com/ember-cli/ember-cli/pull/9451) update blueprint deps~~