### PR TITLE
update empress-blog-ember-template

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "ember-source": "~3.25.1",
         "ember-template-lint": "^2.18.1",
         "empress-blog": "^3.0.2",
-        "empress-blog-ember-template": "^1.1.2",
+        "empress-blog-ember-template": "^1.2.0",
         "eslint": "^7.20.0",
         "eslint-config-prettier": "^7.2.0",
         "eslint-plugin-ember": "^10.2.0",
@@ -16937,9 +16937,9 @@
       }
     },
     "node_modules/empress-blog-ember-template": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/empress-blog-ember-template/-/empress-blog-ember-template-1.1.2.tgz",
-      "integrity": "sha512-TBVAd2IUR2SqZhTuLUOBoy5xvslpbjmTNAwGZz99QBlBScclBYWRmqcIWfBTTdOrMA3b01WFJrClFHnC91gzag==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/empress-blog-ember-template/-/empress-blog-ember-template-1.2.0.tgz",
+      "integrity": "sha512-Ctzt/VU4T/jsOSyN18+qXDxof6HOIPfWLwxZJ9t6Dc3NjoyS5gu4RVu/YjIGgwtIEfP01c47CemYtRcj7IzdHw==",
       "dev": true,
       "dependencies": {
         "@glimmer/component": "^1.0.1",
@@ -46962,9 +46962,9 @@
       }
     },
     "empress-blog-ember-template": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/empress-blog-ember-template/-/empress-blog-ember-template-1.1.2.tgz",
-      "integrity": "sha512-TBVAd2IUR2SqZhTuLUOBoy5xvslpbjmTNAwGZz99QBlBScclBYWRmqcIWfBTTdOrMA3b01WFJrClFHnC91gzag==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/empress-blog-ember-template/-/empress-blog-ember-template-1.2.0.tgz",
+      "integrity": "sha512-Ctzt/VU4T/jsOSyN18+qXDxof6HOIPfWLwxZJ9t6Dc3NjoyS5gu4RVu/YjIGgwtIEfP01c47CemYtRcj7IzdHw==",
       "dev": true,
       "requires": {
         "@glimmer/component": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ember-source": "~3.25.1",
     "ember-template-lint": "^2.18.1",
     "empress-blog": "^3.0.2",
-    "empress-blog-ember-template": "^1.1.2",
+    "empress-blog-ember-template": "^1.2.0",
     "eslint": "^7.20.0",
     "eslint-config-prettier": "^7.2.0",
     "eslint-plugin-ember": "^10.2.0",


### PR DESCRIPTION
This brings template version 1.2.0 https://github.com/ember-learn/empress-blog-ember-template/releases/tag/v1.2.0 to the blog 

The main thing that this version brings is the updated ember-times logo 