### PR TITLE
Fixes broken anchor links in certain articles

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -23,6 +23,11 @@ module.exports = function (environment) {
       // when it is created
     },
 
+    showdown: {
+      ghCompatibleHeaderId: true,
+      prefixHeaderId: 'toc_',
+    },
+
     blog: {
       title: 'Ember.js Blog',
       description: 'Official Blog for the Ember.js Open Source Project',


### PR DESCRIPTION
## What it does
<!--- Tell us what this fix does in a few sentences. E.g. "This updates the header title's font color to Ember Orange." -->
The updated environment-config fixes anchor links in certain articles that, when clicked, did not scroll down to the respective section.

## Related Issue(s)
<!--- Please provide the issue(s) to which this pull request relates to or which issue it closes. E.g. "Closes #1234" -->
Closes #958 
