### PR TITLE
Adds GAAD 2021 blog post

### DIFF
--- a/content/gaad-2021.md
+++ b/content/gaad-2021.md
@@ -1,0 +1,39 @@
+---
+title: The Ember JS Framework Takes the GAAD Pledge
+authors:
+  - melanie-sumner
+date: 2021-05-20T00:00:00.000Z
+tags:
+  - recent-news
+  - accessibility
+  - '2021'
+---
+
+While we join [Global Accessibility Awareness Day](https://globalaccessibilityawarenessday.org/)  (GAAD) in celebrating its tenth anniversary, we are delighted to announce that the [Ember JavaScript Framework](https://emberjs.com/) has taken the GAAD pledge **to make accessibility a core value of our framework**.
+
+For those who know the project well, this will come as no surprise. It’s no secret that we think that accessibility is an integral part of quality code. [Ember.js](https://github.com/emberjs/ember.js) is committed to providing a well-lit path for developer success, and our plans to make it easier for developers to write accessible code are part of that. In 2020, the Ember Accessibility Strike Team became the [Ember Accessibility Working Group](https://blog.emberjs.com/accessibility-working-group-update), demonstrating our commitment to long-term accessibility growth in the framework.
+
+## What We've Done So Far
+
+Ember has also been shipping improvements with the “accessibility by default” developer experience in mind. These improvements include support for default app language (RFC [#635](https://emberjs.github.io/rfcs/0635-ember-new-lang.html)), default page titles (RFC [#645](https://emberjs.github.io/rfcs/0645-add-ember-page-title-addon.html)), added [content to the guides](https://guides.emberjs.com/release/accessibility/application-considerations/) specifically for accessibility, changes to the [website design](https://ember-styleguide.netlify.app/concepts/colors/) for better accessibility, and addition of accessibility-related linting rules to [Ember Template Lint](https://github.com/ember-template-lint/ember-template-lint). Members of the Accessibility Working Group also published two new addons, [ember-context-id-helper](https://github.com/KamiKillertO/ember-context-id-helper) and [ember-select-light](https://github.com/ember-a11y/ember-select-light), to give developers more tools to craft accessible code.
+
+## What We Have Planned
+
+Looking forward, we have even more accessibility-related work planned. Two RFCs have been merged that target specific improvements; one addresses a way to make it easier to associate elements through unique id attributes in template-only components (RFC [#659](https://emberjs.github.io/rfcs/0659-unique-id-helper.html)), and the other proposes an interactive way to create new Ember apps, ensuring that accessible outcomes are front and center (RFC [#638](https://emberjs.github.io/rfcs/0638-interactive-app-creation.html)).
+
+We will continue on our journey of accessibility with more improvements to the guide prose and code samples, as well as implement targeted improvements to the design of the guides and API documentation. Our goal is to reach [WCAG’s AA level of conformance on our official project websites](https://ember-styleguide.netlify.app/concepts/accessibility/), and we are determined to see this through to completion.
+
+## How You Can Help
+
+We also invite everyone to help make Ember a more accessible framework. There are lots of ways to get involved! Here are just a few:
+
+- Help maintain a11y-specific addons in the [Ember A11y](https://github.com/ember-a11y) organization.
+- Contribute [additional template linting rules](https://github.com/ember-template-lint/ember-template-lint/issues?q=is%3Aopen+is%3Aissue+label%3Aa11y) to Ember Template Lint
+- Tackle an accessibility-related [Help Wanted issue](https://help-wanted.emberjs.com/ember-a11y)
+- Add accessible component patterns to the [Ember Component Patterns](https://github.com/ember-components/ember-component-patterns) Project
+- Provide feedback to the team
+    - by email: core@emberjs.com
+    - on Twitter: [https://twitter.com/emberjs](https://twitter.com/emberjs)
+    - by filing an issue on GitHub: [https://github.com/emberjs/ember.js/issues](https://github.com/emberjs/ember.js/issues)
+
+Today we reaffirm our commitment to accessibility by taking the GAAD Pledge. As we continually improve Ember, accessibility is an integral part of our core values. No matter where you are on your accessibility journey, we invite you to take a closer look at Ember and see the many ways that the framework supports developers to build high-quality applications that are accessible for everyone.

--- a/content/gaad-2021.md
+++ b/content/gaad-2021.md
@@ -9,7 +9,7 @@ tags:
   - '2021'
 ---
 
-While we join [Global Accessibility Awareness Day](https://globalaccessibilityawarenessday.org/)  (GAAD) in celebrating its tenth anniversary, we are delighted to announce that the [Ember JavaScript Framework](https://emberjs.com/) has taken the GAAD pledge **to make accessibility a core value of our framework**.
+As we join [Global Accessibility Awareness Day](https://globalaccessibilityawarenessday.org/) (GAAD) in celebrating its tenth anniversary, we are delighted to announce that the [Ember JavaScript Framework](https://emberjs.com/) has taken the GAAD pledge **to make accessibility a core value of our framework**.
 
 For those who know the project well, this will come as no surprise. It’s no secret that we think that accessibility is an integral part of quality code. [Ember.js](https://github.com/emberjs/ember.js) is committed to providing a well-lit path for developer success, and our plans to make it easier for developers to write accessible code are part of that. In 2020, the Ember Accessibility Strike Team became the [Ember Accessibility Working Group](https://blog.emberjs.com/accessibility-working-group-update), demonstrating our commitment to long-term accessibility growth in the framework.
 

--- a/content/gaad-2021.md
+++ b/content/gaad-2021.md
@@ -4,7 +4,7 @@ authors:
   - melanie-sumner
 date: 2021-05-20T00:00:00.000Z
 tags:
-  - recent-news
+  - announcement
   - accessibility
   - '2021'
 ---

--- a/content/gaad-2021.md
+++ b/content/gaad-2021.md
@@ -25,7 +25,7 @@ We will continue on our journey of accessibility with more improvements to the g
 
 ## How You Can Help
 
-We also invite everyone to help make Ember a more accessible framework. There are lots of ways to get involved! Here are just a few:
+We also invite everyone to help make Ember a more accessible framework. There are lots of ways to get involved! Here are a few ideas:
 
 - Help maintain a11y-specific addons in the [Ember A11y](https://github.com/ember-a11y) organization.
 - Contribute [additional template linting rules](https://github.com/ember-template-lint/ember-template-lint/issues?q=is%3Aopen+is%3Aissue+label%3Aa11y) to Ember Template Lint


### PR DESCRIPTION
This PR adds the Global Accessibility Awareness Day (GAAD) blog post. 

Please do not publish this blog post before May 20th (8am EST). 

Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.