### PR TITLE
Ember 3.27 Release

### DIFF
--- a/content/ember-3-27-released.md
+++ b/content/ember-3-27-released.md
@@ -38,9 +38,9 @@ For a full set of changes see [`CHANGELOG.md`](https://github.com/emberjs/ember.
 
 #### Notable Bug Fixes
 
-* Prior to 3.27 `<:inverse>` would not always alias else blocks. This is
+- Prior to 3.27 `<:inverse>` would not always alias else blocks. This is
 corrected in [glimmerjs/glimmer-vm#1296](https://github.com/glimmerjs/glimmer-vm/pull/1296).
-* Ember.js 3.27.0 was released in early May and included several regressions.
+- Ember.js 3.27.0 was released in early May and included several regressions.
 These were largely related to the changes in the glimmer VM and and the
 implementation of several deprecations.
 
@@ -129,7 +129,7 @@ in Ember 4.0. See the [deprecation guide
 entry](https://deprecations.emberjs.com/v3.x#toc_argument-less-helper-paren-less-invocation)
 for more details.
 
-##### Importing Legacy Built-in Components 
+##### Importing Legacy Built-in Components
 
 Historically, Ember applications have been able to import the base classes which
 define `<Input>`, `<Textarea>`, and `<LinkTo>` for reopening or subclassing. In
@@ -206,8 +206,7 @@ export Component.extend({});
 ```
 
 See [the deprecation
-guide](https://deprecations.emberjs.com/v3.x/#toc_ember-global) and [RFC
-#706](https://github.com/emberjs/rfcs/blob/master/text/0706-deprecate-ember-global.md)
+guide](https://deprecations.emberjs.com/v3.x/#toc_ember-global) and [RFC 706](https://github.com/emberjs/rfcs/blob/master/text/0706-deprecate-ember-global.md)
 for more details and a transition path.
 
 #### Further information
@@ -263,7 +262,7 @@ While it is recommended to keep Ember CLI versions in sync with Ember and Ember 
 Ember CLI 3.27 introduces a flag for enabling Embroider (Ember CLI's new build
 pipeline) for new applications and addons. For example:
 
-```
+```bash
 ember new my-app --embroider
 ```
 

--- a/content/ember-3-27-released.md
+++ b/content/ember-3-27-released.md
@@ -45,7 +45,8 @@ For a full set of changes see [`CHANGELOG.md`](https://github.com/emberjs/ember.
 corrected in [glimmerjs/glimmer-vm#1296](https://github.com/glimmerjs/glimmer-vm/pull/1296).
 - Ember.js 3.27.0 was released in early May and included several regressions.
 These were largely related to the changes in the glimmer VM and and the
-implementation of several deprecations.
+implementation of several deprecations, and have been corrected in patch
+releases leading up to 3.27.5.
 
 ### Feature Additions
 
@@ -100,7 +101,7 @@ And be used as:
 </SuperForm>
 ```
 
-These APIs open the doors for the creation of new, more powerful abstractions.
+These APIs open the doors for the creation of new, more powerful UI abstractions.
 
 ### Deprecations
 
@@ -160,25 +161,25 @@ entry](https://deprecations.emberjs.com/v3.x#toc_ember-built-in-components-impor
 for more details and guidance on migrating away from these APIs.
 
 Additionally, reopening these classes (for example to change the `tagName` on a
-`<LinkTo>` has been deprecated and will be unsupported in 4.0. See [the
+`<LinkTo>`) has been deprecated and will be unsupported in 4.0. See [the
 deprecation guide for migration strategies](https://deprecations.emberjs.com/v3.x/#toc_ember-built-in-components-reopen).
 
 #### Deprecate Legacy Arguments to Built-ins
 
 Ember's built-in components had a public interface largely defined by their
 implementation as classic Ember components. In order to refactor these built-ins
-to a more modern implementation and improve their interface, large parts of
+to more modern implementations and improve their interfaces, large parts of
 their API is deprecated in 3.27.
 
 These deprecations break down into two sections. First, there are arguments
 which are essentially setting HTML attributes or dealing with events. See [this
 guide entry on legacy attribute
 arguments](https://deprecations.emberjs.com/v3.x/#toc_ember-built-in-components-legacy-attribute-arguments)
-for a detailed list of deprecated arguments and migration path.
+for a detailed list of deprecated arguments and migration paths.
 
 Second, there is a set of arguments which were effectively leaks of the private
 implemention, or which no longer have a clear meaning (or usefulness) in modern
-application development. See [this guide entry on legacy arguments](https://deprecations.emberjs.com/v3.x/#toc_ember-built-in-components-legacy-arguments) for a detailed list and migration path.
+application development. See [this guide entry on legacy arguments](https://deprecations.emberjs.com/v3.x/#toc_ember-built-in-components-legacy-arguments) for a detailed list and migration paths.
 
 #### Deprecate the Ember Global
 
@@ -195,24 +196,24 @@ either the `Ember` object or a specific API from the module API:
 
 ```js
 // Bad, deprecated
-export Ember.Component.extend({});
+export default Ember.Component.extend({});
 ```
 
 ```js
 // Better
 import Ember from 'ember';
-export Ember.Component.extend({});
+export default Ember.Component.extend({});
 ```
 
 ```js
 // Best
 import Component from '@ember/component';
-export Component.extend({});
+export default Component.extend({});
 ```
 
 See [the deprecation
 guide](https://deprecations.emberjs.com/v3.x/#toc_ember-global) and [RFC 706](https://github.com/emberjs/rfcs/blob/master/text/0706-deprecate-ember-global.md)
-for more details and a transition path.
+for more details and transition paths for other use cases.
 
 ### Further Information On Upgrade Timelines
 
@@ -225,13 +226,14 @@ ember-cli-deprecation-workflow 2.0 was released *today* in preperation for
 applications addressing Ember 3.x deprecations. Give us feedback in the issues
 on that repo.
 
-For app maintainers who are in less of a hurry, **please note that Ember.js 3.28
-will contain no new deprecations targeting Emer.js 4.0**. Additionally, Ember.js
+For app maintainers who are in less of a hurry, **please note that the upcoming
+release of Ember.js 3.28
+will contain no new deprecations targeting Ember.js 4.0**. Additionally, Ember.js
 3.28 will be promoted to LTS on the same day Ember.js 4.0 is released.
 
 We recommend that applications using LTS releases wait for the first LTS of
 Ember.js 4.x to upgrade, which will be Ember.js 4.4. Ember's 6 week release
-cycle means we expect there is about 44 weeks for apps upgrading from LTS-to-LTS
+cycle means we expect there is about 44 weeks (from today) for apps upgrading from LTS-to-LTS
 to address 4.0-targeted deprecations before Ember.js 4.4-LTS is made available.
 
 For more details on changes in Ember.js 3.27, please review the [Ember.js 3.27.5 release page](https://github.com/emberjs/ember.js/blob/master/CHANGELOG.md#v3275-june-10-2021).

--- a/content/ember-3-27-released.md
+++ b/content/ember-3-27-released.md
@@ -47,9 +47,9 @@ corrected in [glimmerjs/glimmer-vm#1296](https://github.com/glimmerjs/glimmer-vm
 These were largely related to the changes in the glimmer VM and and the
 implementation of several deprecations.
 
-### Features
+### Feature Additions
 
-#### Contextual helpers & modifiers
+#### Contextual Helpers & Modifiers
 
 For several years Ember has provided a mechanism called "contextual components".
 This API allows a developer to yield a component, optionally with arguments
@@ -117,7 +117,7 @@ In some templates, a helper passed as an argument can be treated as an
 invocation instead of passing the uninvoked helper as a value. For example:
 
 ```handlebars
-{{! is someHelper invoked, or pass as a reference? }}
+{{! is someHelper invoked, or passed as a reference? }}
 <SomeComponent @arg={{someHelper}} />
 ```
 
@@ -194,20 +194,17 @@ Instead, applications should adopt the Ember module API. This means importing
 either the `Ember` object or a specific API from the module API:
 
 ```js
-// app/components/some-component.js
 // Bad, deprecated
 export Ember.Component.extend({});
 ```
 
 ```js
-// app/components/some-component.js
 // Better
 import Ember from 'ember';
 export Ember.Component.extend({});
 ```
 
 ```js
-// app/components/some-component.js
 // Best
 import Component from '@ember/component';
 export Component.extend({});
@@ -217,7 +214,7 @@ See [the deprecation
 guide](https://deprecations.emberjs.com/v3.x/#toc_ember-global) and [RFC 706](https://github.com/emberjs/rfcs/blob/master/text/0706-deprecate-ember-global.md)
 for more details and a transition path.
 
-### Further information
+### Further Information On Upgrade Timelines
 
 For application maintainers who want to upgrade apps to Ember.js 4.0 on its release date, the list of
 deprecations in this release means their challenge is now well defined.

--- a/content/ember-3-27-released.md
+++ b/content/ember-3-27-released.md
@@ -19,6 +19,8 @@ become an LTS release. As of the 3.28-beta being released, the main development
 branch of all Ember projects will become 4.0. Look for more information on Ember
 4.0 here on the blog this coming week.
 
+<!-- READMORE -->
+
 You can read more about our general release process with these resources:
 
 - [Release Dashboard](http://emberjs.com/releases/)
@@ -37,7 +39,7 @@ Ember.js is the core framework for building ambitious web applications.
 Ember.js 3.27 is an incremental, backwards compatible release of Ember with bug fixes, performance improvements, and deprecations.
 For a full set of changes see [`CHANGELOG.md`](https://github.com/emberjs/ember.js/blob/master/CHANGELOG.md#v3275-june-10-2021).
 
-#### Notable Bug Fixes
+### Notable Bug Fixes
 
 - Prior to 3.27 `<:inverse>` would not always alias else blocks. This is
 corrected in [glimmerjs/glimmer-vm#1296](https://github.com/glimmerjs/glimmer-vm/pull/1296).
@@ -45,9 +47,9 @@ corrected in [glimmerjs/glimmer-vm#1296](https://github.com/glimmerjs/glimmer-vm
 These were largely related to the changes in the glimmer VM and and the
 implementation of several deprecations.
 
-#### Features
+### Features
 
-##### Contextual helpers & modifiers
+#### Contextual helpers & modifiers
 
 For several years Ember has provided a mechanism called "contextual components".
 This API allows a developer to yield a component, optionally with arguments
@@ -59,7 +61,8 @@ the same way.
 
 For example the layout for a `SuperForm` component might be implemented as:
 
-```app/components/super-form/template.hbs
+```handlebars
+// app/components/super-form.hbs
 <form>
   {{yield (hash
 
@@ -78,7 +81,8 @@ For example the layout for a `SuperForm` component might be implemented as:
 
 And be used as:
 
-```app/templates/index.hbs
+```handlebars
+// app/templates/index.hbs
 <SuperForm @model={{this.post}} as |f|>
 
   {{! Invoke a contextual component }}
@@ -98,7 +102,7 @@ And be used as:
 
 These APIs open the doors for the creation of new, more powerful abstractions.
 
-#### Deprecations
+### Deprecations
 
 Ember 3.27 introduces the final set of deprecations targeting Ember 4.0. The
 newly introduced deprecations primarily impact uncommonly used APIs. As always,
@@ -107,12 +111,12 @@ guides](https://deprecations.emberjs.com/v3.x).
 
 Several notable deprecations added in 3.27 are:
 
-##### Invoking Helpers Without Arguments and Parentheses in Named Argument Positions
+#### Invoking Helpers Without Arguments and Parentheses in Named Argument Positions
 
 In some templates, a helper passed as an argument can be treated as an
 invocation instead of passing the uninvoked helper as a value. For example:
 
-```hbs
+```handlebars
 {{! is someHelper invoked, or pass as a reference? }}
 <SomeComponent @arg={{someHelper}} />
 ```
@@ -120,7 +124,7 @@ invocation instead of passing the uninvoked helper as a value. For example:
 To better align helpers with how component and modifiers behave in the same
 setting, parenthesis are now required to cause an invocation:
 
-```hbs
+```handlebars
 {{! (someHelper) is clearly an invocation with no arguments }}
 <SomeComponent @arg={{(someHelper)}} />
 ```
@@ -130,7 +134,7 @@ in Ember 4.0. See the [deprecation guide
 entry](https://deprecations.emberjs.com/v3.x#toc_argument-less-helper-paren-less-invocation)
 for more details.
 
-##### Importing Legacy Built-in Components
+#### Importing Legacy Built-in Components
 
 Historically, Ember applications have been able to import the base classes which
 define `<Input>`, `<Textarea>`, and `<LinkTo>` for reopening or subclassing. In
@@ -159,7 +163,7 @@ Additionally, reopening these classes (for example to change the `tagName` on a
 `<LinkTo>` has been deprecated and will be unsupported in 4.0. See [the
 deprecation guide for migration strategies](https://deprecations.emberjs.com/v3.x/#toc_ember-built-in-components-reopen).
 
-##### Deprecate Legacy Arguments to Built-ins
+#### Deprecate Legacy Arguments to Built-ins
 
 Ember's built-in components had a public interface largely defined by their
 implementation as classic Ember components. In order to refactor these built-ins
@@ -176,7 +180,7 @@ Second, there is a set of arguments which were effectively leaks of the private
 implemention, or which no longer have a clear meaning (or usefulness) in modern
 application development. See [this guide entry on legacy arguments](https://deprecations.emberjs.com/v3.x/#toc_ember-built-in-components-legacy-arguments) for a detailed list and migration path.
 
-##### Deprecate the Ember Global
+#### Deprecate the Ember Global
 
 Ember has long set a property on the `window` or `globalThis` global so that
 it can be accessed via `window.Ember`, for example. This approach to using Ember
@@ -189,18 +193,21 @@ deprecated. Support for using Ember this way will be removed in Ember 4.0.
 Instead, applications should adopt the Ember module API. This means importing
 either the `Ember` object or a specific API from the module API:
 
-```app/components/some-component/component.js
+```js
+// app/components/some-component.js
 // Bad, deprecated
 export Ember.Component.extend({});
 ```
 
-```app/components/some-component/component.js
+```js
+// app/components/some-component.js
 // Better
 import Ember from 'ember';
 export Ember.Component.extend({});
 ```
 
 ```js
+// app/components/some-component.js
 // Best
 import Component from '@ember/component';
 export Component.extend({});
@@ -210,7 +217,7 @@ See [the deprecation
 guide](https://deprecations.emberjs.com/v3.x/#toc_ember-global) and [RFC 706](https://github.com/emberjs/rfcs/blob/master/text/0706-deprecate-ember-global.md)
 for more details and a transition path.
 
-#### Further information
+### Further information
 
 For application maintainers who want to upgrade apps to Ember.js 4.0 on its release date, the list of
 deprecations in this release means their challenge is now well defined.

--- a/content/ember-3-27-released.md
+++ b/content/ember-3-27-released.md
@@ -3,7 +3,7 @@ title: Ember 3.27 Released
 authors:
   - matthew-beale
   - ricardo-mendes
-  date: 2021-07-02T00:00:00.000Z
+date: 2021-07-02T00:00:00.000Z
 tags:
   - releases
   - '2021'

--- a/content/ember-3-27-released.md
+++ b/content/ember-3-27-released.md
@@ -1,0 +1,116 @@
+---
+title: Ember 3.27 Released
+authors:
+  - the-crowd # replace with real authors from the author folder (add yourself if you're not there)
+date: 2021-05-XXT00:00:00.000Z
+tags:
+  - releases
+  - '2021'
+  - version-3-x
+---
+
+Today the Ember project is releasing version 3.27 of Ember.js, Ember Data, and Ember CLI. <!-- Block start: Uncomment if an LTS candidate --><!--This release of Ember.js is an LTS (Long Term Support) candidate. LTS candidates prioritize stability over the addition of new features, and have an extended support schedule.--><!-- Block end -->
+
+This release kicks off the 3.28 beta cycle for all sub-projects. We encourage our community (especially addon authors) to help test these beta builds and report any bugs before they are published as a final release in six weeks' time. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
+
+You can read more about our general release process here:
+
+- [Release Dashboard](http://emberjs.com/releases/)
+- [The Ember Release Cycle](https://blog.emberjs.com/new-ember-release-process/)
+- [The Ember Project](https://blog.emberjs.com/ember-project-at-2-0/)
+- [Ember LTS Releases](https://blog.emberjs.com/announcing-embers-first-lts/)
+
+---
+
+## Ember.js
+
+Ember.js is the core framework for building ambitious web applications.
+
+### Changes in Ember.js 3.27
+
+Ember.js 3.27 is an incremental, backwards compatible release of Ember with bug fixes, performance improvements, and minor deprecations.
+
+#### Bug Fixes
+
+Ember.js 3.27 introduced 0 bug fixes.
+
+#### Features
+
+Ember.js 3.27 introduced 2 features.
+
+1. Feature description
+2. Feature description
+
+#### Deprecations
+
+Ember.js 3.27 introduced 0 deprecations.
+
+<!-- Block start: If there were no deprecations, remove this block -->
+Deprecations are added to Ember.js when an API will be removed at a later date. Each deprecation has an entry in the deprecation guide describing the migration path to a more stable API. Deprecated public APIs are not removed until a major release of the framework.
+
+Consider using the [ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow) addon if you would like to upgrade your application without immediately addressing deprecations.
+<!-- Block end -->
+
+For more details on changes in Ember.js 3.27, please review the [Ember.js 3.27.0 release page](https://github.com/emberjs/ember.js/releases/tag/v3.27.0).
+
+---
+
+## Ember Data
+
+Ember Data is the official data persistence library for Ember.js applications.
+
+### Changes in Ember Data 3.27
+
+#### Bug Fixes
+
+Ember Data 3.27 introduced 0 bug fixes.
+
+#### Features
+
+Ember Data 3.27 introduced 0 features.
+
+#### Deprecations
+
+Ember Data 3.27 introduced 0 deprecations.
+
+For more details on changes in Ember Data 3.27, please review the
+[Ember Data 3.27.0 release page](https://github.com/emberjs/data/releases/tag/v3.27.0).
+
+---
+
+## Ember CLI
+
+Ember CLI is the command line interface for managing and packaging Ember.js applications.
+
+### Upgrading Ember CLI
+
+You may upgrade Ember CLI using the `ember-cli-update` project:
+
+```bash
+npx ember-cli-update
+```
+
+This utility will help you to update your app or addon to the latest Ember CLI version. You will probably encounter merge conflicts, in which the default behavior is to let you resolve conflicts on your own. For more information on the `ember-cli-update` project, see [the GitHub README](https://github.com/ember-cli/ember-cli-update).
+
+While it is recommended to keep Ember CLI versions in sync with Ember and Ember Data, this is not required. After updating ember-cli, you can keep your current version(s) of Ember or Ember Data by editing `package.json` to revert the changes to the lines containing `ember-source` and `ember-data`.
+
+### Changes in Ember CLI 3.27
+
+#### Bug Fixes
+
+Ember CLI 3.27 introduced 0 bug fixes.
+
+#### Features
+
+Ember CLI 3.27 introduced 0 features.
+
+#### Deprecations
+
+Ember CLI 3.27 introduced 0 deprecations.
+
+For more details on the changes in Ember CLI 3.27 and detailed upgrade
+instructions, please review the [Ember CLI 3.27.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.27.0).
+
+## Thank You!
+
+As a community-driven open-source project with an ambitious scope, each of these releases serves as a reminder that the Ember project would not have been possible without your continued support. We are extremely grateful to our contributors for their efforts.

--- a/content/ember-3-27-released.md
+++ b/content/ember-3-27-released.md
@@ -10,15 +10,16 @@ tags:
   - version-3-x
 ---
 
-Today the Ember project is announcing release 3.27 of Ember.js, Ember Data, and Ember CLI.
+Today the Ember project is announcing release 3.27 of Ember.js, Ember Data, and Ember CLI. This is a minor version, stable release.
 
-This release kicks off the 3.28 beta cycle for all sub-projects. We encourage our community (especially addon authors) to help test these beta builds and report any bugs before they are published as a final release in six weeks' time. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
+We're also announcing the start of the 3.28 beta cycle for all sub-projects. We encourage our community (especially addon authors) to help test beta builds and report any bugs before they are published as a stable release in six weeks' time. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
 
-Ember.js 3.28 is the final planned version of the 3.x release cycle, and will
+Ember.js 3.28 (again, starting **beta** today) is the final planned version of the 3.x release cycle, and will
 become an LTS release. As of the 3.28-beta being released, the main development
-branch of all Ember projects will become 4.0.
+branch of all Ember projects will become 4.0. Look for more information on Ember
+4.0 here on the blog this coming week.
 
-You can read more about our general release process here:
+You can read more about our general release process with these resources:
 
 - [Release Dashboard](http://emberjs.com/releases/)
 - [The Ember Release Cycle](https://blog.emberjs.com/new-ember-release-process/)
@@ -33,8 +34,8 @@ Ember.js is the core framework for building ambitious web applications.
 
 ### Changes in Ember.js 3.27
 
-Ember.js 3.27 is an incremental, backwards compatible release of Ember with bug fixes, performance improvements, and minor deprecations.
-For a full set of changes see [`CHANGELOG.md`](https://github.com/emberjs/ember.js/blob/master/CHANGELOG.md#v3270-may-3-2021).
+Ember.js 3.27 is an incremental, backwards compatible release of Ember with bug fixes, performance improvements, and deprecations.
+For a full set of changes see [`CHANGELOG.md`](https://github.com/emberjs/ember.js/blob/master/CHANGELOG.md#v3275-june-10-2021).
 
 #### Notable Bug Fixes
 
@@ -104,7 +105,7 @@ newly introduced deprecations primarily impact uncommonly used APIs. As always,
 deprecated APIs are documented with a transition path in the [deprecation
 guides](https://deprecations.emberjs.com/v3.x).
 
-Several notable deprecations include:
+Several notable deprecations added in 3.27 are:
 
 ##### Invoking Helpers Without Arguments and Parentheses in Named Argument Positions
 
@@ -211,12 +212,14 @@ for more details and a transition path.
 
 #### Further information
 
-For apps which want to upgrade to Ember.js 4.0 on its release date, the list of
+For application maintainers who want to upgrade apps to Ember.js 4.0 on its release date, the list of
 deprecations in this release means their challenge is now well defined.
 Application maintainers should consider using the
 [ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow)
-addon to address deprecations incrementally after upgrading to 3.27. Keep an eye
-out for ember-cli-deprecation-workflow 2.0 in the coming days.
+addon to address deprecations incrementally after upgrading to 3.27.
+ember-cli-deprecation-workflow 2.0 was released *today* in preperation for
+applications addressing Ember 3.x deprecations. Give us feedback in the issues
+on that repo.
 
 For app maintainers who are in less of a hurry, **please note that Ember.js 3.28
 will contain no new deprecations targeting Emer.js 4.0**. Additionally, Ember.js
@@ -265,6 +268,9 @@ pipeline) for new applications and addons. For example:
 ```bash
 ember new my-app --embroider
 ```
+
+Learn more about what Embroider offers and how to best configure it on the
+[embroider-build/embroider](https://github.com/embroider-build/embroider) repo.
 
 For more details on changes and bugfixes in Ember CLI 3.27, see the [Ember 2.7.0
 changelog](https://github.com/ember-cli/ember-cli/blob/v3.27.0/CHANGELOG.md#v3270)


### PR DESCRIPTION
[Rendered](https://github.com/ember-learn/ember-blog/blob/release-3-27/content/ember-3-27-released.md)

## Changelogs

### Ember

- [#19597](https://github.com/emberjs/ember.js/pull/19597) [BIGFIX] Fix `<LinkTo>` with nested children
- [#19594](https://github.com/emberjs/ember.js/pull/19594) [BUGFIX] Revert lazy hash changes
- [#19596](https://github.com/emberjs/ember.js/pull/19596) [DOC] Fix "Dormant" addon warning typo
- [#19565](https://github.com/emberjs/ember.js/pull/19565) [BUGFIX] Ensures that `computed` can depend on dynamic `(hash` keys
- [#19571](https://github.com/emberjs/ember.js/pull/19571) [BUGFIX] Extend `Route.prototype.transitionTo` deprecation until 5.0.0
- [#19586](https://github.com/emberjs/ember.js/pull/19586) [BUGFIX] Fix Embroider compatibility
- [#19511](https://github.com/emberjs/ember.js/pull/19511) / [#19548](https://github.com/emberjs/ember.js/pull/19548) [BUGFIX] Makes the (hash) helper lazy
- [#19530](https://github.com/emberjs/ember.js/pull/19530) [DOC] fix passing params to named blocks examples
- [#19536](https://github.com/emberjs/ember.js/pull/19536) [BUGFIX] Fix `computed.*` deprecation message to include the correct import path
- [#19544](https://github.com/emberjs/ember.js/pull/19544) [BUGFIX] Use explicit this in helper test blueprints
- [#19555](https://github.com/emberjs/ember.js/pull/19555) [BUGFIX] Improve class based tranform deprecation message
- [#19557](https://github.com/emberjs/ember.js/pull/19557) [BUGFIX] Refine Ember Global deprecation message
- [#19564](https://github.com/emberjs/ember.js/pull/19564) [BUGFIX] Improve computed.* and run.* deprecation message (IE11)
- [#19540](https://github.com/emberjs/ember.js/pull/19540) [BUGFIX] Ensure ember-testing is loaded lazily
- [#19541](https://github.com/emberjs/ember.js/pull/19541) [BUGFIX] Add missing metadata for some deprecations enabled in 3.27.0
- [#19541](https://github.com/emberjs/ember.js/pull/19541) [BUGFIX] Ensure passing `@href` to `<LinkTo>` throws an error
- [#19541](https://github.com/emberjs/ember.js/pull/19541) [CLEANUP] Consistently use https://deprecations.emberjs.com/ in deprecation URLs
- [#19309](https://github.com/emberjs/ember.js/pull/19309) / [#19487](https://github.com/emberjs/ember.js/pull/19487) / [#19474](https://github.com/emberjs/ember.js/pull/19474) [FEATURE] Enable `(helper` and `(modifier` helpers per [RFC #432](https://github.com/emberjs/rfcs/blob/master/text/0432-contextual-helpers.md).
- [#19382](https://github.com/emberjs/ember.js/pull/19382) / [#19430](https://github.com/emberjs/ember.js/pull/19430) [FEATURE] Remaining implementation work per [RFC #671](https://github.com/emberjs/rfcs/blob/master/text/0671-modernize-built-in-components-1.md).
- [#19457](https://github.com/emberjs/ember.js/pull/19457) / [#19463](https://github.com/emberjs/ember.js/pull/19463) / [#19464](https://github.com/emberjs/ember.js/pull/19464) / [#19467](https://github.com/emberjs/ember.js/pull/19467) [DEPRECATION] Add deprecation for the Ember Global per [RFC #706](https://github.com/emberjs/rfcs/blob/master/text/0706-deprecate-ember-global.md).
- [#19407](https://github.com/emberjs/ember.js/pull/19407) [DEPRECATION] Add deprecation for `Route#disconnectOutlet` per [RFC #491](https://github.com/emberjs/rfcs/blob/master/text/0491-deprecate-disconnect-outlet.md).
- [#19433](https://github.com/emberjs/ember.js/pull/19433) [DEPRECATION] Add deprecation for `Route#renderTemplate` per [RFC #418](https://github.com/emberjs/rfcs/blob/master/text/0418-deprecate-route-render-methods.md).
- [#19442](https://github.com/emberjs/ember.js/pull/19442) [DEPRECATION] Add deprecation for `Route#render` method per [RFC #418](https://github.com/emberjs/rfcs/blob/master/text/0418-deprecate-route-render-methods.md).
- [#19429](https://github.com/emberjs/ember.js/pull/19429) [DEPRECATION] `registerPlugin` / `unregisterPlugin` and legacy class based AST plugins (private APIs)
- [#19499](https://github.com/emberjs/ember.js/pull/19499) [DEPRECATION] Deprecate `@foo={{helper}}` per [RFC #496](https://github.com/emberjs/rfcs/blob/master/text/0496-handlebars-strict-mode.md#3-no-implicit-invocation-of-argument-less-helpers).
- [#19499](https://github.com/emberjs/ember.js/pull/19499) [BUGFIX] Update rendering engine to `@glimmer/*` 0.78.2 for fixes including:
    - `<:else>` and `<:inverse>` should be aliases (see https://github.com/glimmerjs/glimmer-vm/pull/1296)
    - Fix nested calls to helpers in dynamic helpers (see https://github.com/glimmerjs/glimmer-vm/pull/1293)
- [#19477](https://github.com/emberjs/ember.js/pull/19477) [BUGFIX] Allow `<LinkToExternal />` to override internal assertion
- [#19481](https://github.com/emberjs/ember.js/pull/19481) [BUGFIX] Export `on` from correct path
- [#19466](https://github.com/emberjs/ember.js/pull/19466) [BUGFIX] Rename private runloop functions
- [#19384](https://github.com/emberjs/ember.js/pull/19384) Use qunit-dom in helper and component test blueprints
- [#19390](https://github.com/emberjs/ember.js/pull/19390) Refactor the internal Ember loader to use the standard Ember CLI loader
- [#19441](https://github.com/emberjs/ember.js/pull/19441) Add automated publishing of weekly alpha releases to NPM
- [#19462](https://github.com/emberjs/ember.js/pull/19462) Use `positional` and `named` as the argument names in `ember g helper` blueprint

### Ember CLI

- [#9504](https://github.com/ember-cli/ember-cli/pull/9504) Update minimum version of broccoli-concat to address a major issue with cache invalidation [@brendenpalmer](https://github.com/brendenpalmer)
- [#9535](https://github.com/ember-cli/ember-cli/pull/9535) Disable Embroider by default. [@rwjblue](https://github.com/rwjblue)
- [#9557](https://github.com/ember-cli/ember-cli/pull/9557) Update app and addon blueprint dependencies to latest. [@rwjblue](https://github.com/rwjblue)
- [#9558](https://github.com/ember-cli/ember-cli/pull/9558) Switch from `octane` template lint config to `recommended` [@bmish](https://github.com/bmish)
- [#9453](https://github.com/ember-cli/ember-cli/pull/9453) Prevent "yarn-error.log" files being published for addons [@bertdeblock](https://github.com/bertdeblock)
- [#9392](https://github.com/ember-cli/ember-cli/pull/9392) / [#9484](https://github.com/ember-cli/ember-cli/pull/9484) Add eslint-plugin-qunit to blueprint [@bmish](https://github.com/bmish)
- [#9454](https://github.com/ember-cli/ember-cli/pull/9454) / [#9492](https://github.com/ember-cli/ember-cli/pull/9492) Add --embroider as an option for new and init [@thoov](https://github.com/thoov)
- [#9456](https://github.com/ember-cli/ember-cli/pull/9456) Add `.*/` to eslint ignore [@chancancode](https://github.com/chancancode)
- [#9469](https://github.com/ember-cli/ember-cli/pull/9469) Run `lint:fix` script automatically after blueprint generation [@rpemberton](https://github.com/rpemberton)
- [#9480](https://github.com/ember-cli/ember-cli/pull/9480) Refactor getPort to only check required port [@Cartmanishere](https://github.com/Cartmanishere)
- [#9485](https://github.com/ember-cli/ember-cli/pull/9485) Add Ember 3.24 LTS to ember-try configuration [@bertdeblock](https://github.com/bertdeblock)
- [#9488](https://github.com/ember-cli/ember-cli/pull/9488) Update supported Ember version in addon blueprint [@bertdeblock](https://github.com/bertdeblock)
- [#9490](https://github.com/ember-cli/ember-cli/pull/9490) Prevent window.Ember deprecation on Ember 3.27+. [@rwjblue](https://github.com/rwjblue)
- [#9491](https://github.com/ember-cli/ember-cli/pull/9491) Update supported Ember CLI version in addon blueprint [@bertdeblock](https://github.com/bertdeblock)
- [#9495](https://github.com/ember-cli/ember-cli/pull/9495) Enable Embroider by default for new projects [@thoov](https://github.com/thoov)
- [#9500](https://github.com/ember-cli/ember-cli/pull/9500) Fix `lint:fix` script for Windows users [@lupestro](https://github.com/lupestro)


### Ember Data

- [#7435](https://github.com/emberjs/data/pull/7435) [Test]: fix for DataWrapper refactor in emberjs (#7435)
