### PR TITLE
Fix unstable ELS writeup

### DIFF
--- a/content/the-ember-times-issue-183.md
+++ b/content/the-ember-times-issue-183.md
@@ -17,7 +17,7 @@ New release of Unstable Ember Language Server, share code snippets on Twitter us
 
 ## [Release of uELS v2.0.16 ✅](https://discord.com/channels/480462759797063690/480499624663056390/845766724040523786)
 
-[Unstable Ember Language Server](https://marketplace.visualstudio.com/items?itemName=lifeart.vscode-ember-unstable) is a fully featured fork of Ember Language Server. While the name says _unstable_ it actually has been **stable** and ready to use for day-to-day development!
+[Unstable Ember Language Server](https://github.com/lifeart/ember-language-server) is a fully featured fork of Ember Language Server. While the name says _unstable_ it actually has been **stable** and ready to use for day-to-day development!
 
 Thanks to both [Alex LaFroscia (@alexlafroscia)](https://github.com/alexlafroscia) and [Alex Kanunnikov (@lifeart)](https://github.com/lifeart) for new version release which provides:
 
@@ -27,7 +27,7 @@ Thanks to both [Alex LaFroscia (@alexlafroscia)](https://github.com/alexlafrosci
 * Added template-lint severity support
 * Improved template-linting speed
 
-Try out uELS today by installing over [Open VSX](https://open-vsx.org/extension/lifeart/vscode-ember-unstable) or [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=lifeart.vscode-ember-unstable)!
+Try out uELS today by installing over [Open VSX](https://open-vsx.org/extension/lifeart/vscode-ember-unstable), [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=lifeart.vscode-ember-unstable), or [neoVim](https://github.com/NullVoxPopuli/coc-ember). uELS also works on Emacs using [lsp-mode](https://github.com/emacs-lsp/lsp-mode).
 
 ---
 


### PR DESCRIPTION
## What it does
<!--- Tell us what this fix does in a few sentences. E.g. "This updates the header title's font color to Ember Orange." -->

Add correction re: uELS to include more editors than just VSCode

@lifeart you mentioned "same link works for GitPod (cloud editor)", which link is that? Please let me know if you have other feedback as well. Will @ madnificent in Discord because am not sure of his GitHub handle.

P.S. Will the name be changed to remove "unstable"? Let me know if can help / also we can do another writeup then? 

Resolves checkbox on: https://github.com/ember-learn/ember-blog/pull/1002