### PR TITLE
Ember 3.28 release

### DIFF
--- a/content/ember-3-28-released.md
+++ b/content/ember-3-28-released.md
@@ -3,6 +3,7 @@ title: Ember 3.28 and 4.0 Beta Released
 authors:
   - matthew-beale
   - isaac-lee
+  - jen-weber
 date: 2021-09-02T00:00:00.000Z
 tags:
   - releases

--- a/content/ember-3-28-released.md
+++ b/content/ember-3-28-released.md
@@ -4,7 +4,7 @@ authors:
   - matthew-beale
   - isaac-lee
   - jen-weber
-date: 2021-09-02T00:00:00.000Z
+date: 2021-09-07T00:00:00.000Z
 tags:
   - releases
   - '2021'
@@ -13,13 +13,13 @@ tags:
 
 After 3.5 years and 28 minor releases, Ember 3.28 marks the end of the project's 3.x series.
 To ensure a smooth upgrade path going into the 4.x series, 3.28 has been declared an LTS (Long Term Support) candidate. In six weeks
-the latest patch version of 3.28 will be promoted to be the latest LTS release
+the latest patch version of 3.28 will be promoted to be the latest LTS release,
 replacing 3.24-LTS.
 
-**We're also announcing the start of the Ember 4.0 beta cycle for all sub-projects.** Following the process set in previous major versions, Ember 4.0 introduces no new features. Instead, it removes support for deprecated public APIs. We encourage our community (especially addon authors) to help test beta builds and report any bugs before they are published as a stable release in six weeks' time. We also encourage everyone to help maintainers resolve deprecations in their favorite addons. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
+**We're also announcing the start of the Ember 4.0 beta cycle for all sub-projects.** Following the process set in previous major versions, Ember 4.0's beta introduces no new features. Instead, it removes support for deprecated public APIs. We encourage our community (especially addon authors) to help test beta builds and report any bugs before they are published as a stable release in six weeks' time. We also encourage everyone to help maintainers resolve deprecations in their favorite addons. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
 
-Developers who want to prepare for the upcoming 4.0 version of Ember should work to resolve all deprecation warnings in their apps and addons.
-An app or addon with no deprecation warnings should be able to upgrade from Ember 3.28 to 4.0 without making significant changes outside of the
+Developers who want to prepare for the upcoming 4.0 version of Ember should work to resolve all deprecation warnings in their apps and addons while using Ember 3.28.
+An app or addon with no deprecation warnings on Ember 3.28 should be able to upgrade from Ember 4.0 without making significant changes outside of the
 dependency versions.
 
 You can read more about Ember's plans for 4.0 in [The Road to Ember 4.0](https://blog.emberjs.com/the-road-to-ember-4-0/).
@@ -32,17 +32,11 @@ Ember.js is the core framework for building ambitious web applications.
 
 ### Changes in Ember.js 3.28
 
-Ember.js 3.28 is an incremental, backwards compatible release of Ember with bug fixes, performance improvements, and minor deprecations. 3.28 is light on changes because we want the final release of the 3.x cycle to be as stable and battle-tested as possible, so it does not have new features.
+Ember.js 3.28 is an incremental, backwards compatible release of Ember with bug fixes, performance improvements, and a minor deprecation fix. 3.28 introduces no new features, helping to ensure the final release of the 3.x cycle is stable and battle-tested.
 
-#### Bug Fixes
+For the full set of changes (including 7 bug fixes), see the [Ember.js 3.28.0 release page](https://github.com/emberjs/ember.js/releases/tag/v3.28.0) on GitHub.
 
-Ember.js 3.28 introduced 7 bug fixes. For the full set of changes, see the [Release notes changelog](https://github.com/emberjs/ember.js/releases/tag/v3.28.0).
-
-#### Deprecations
-
-Ember.js 3.28 introduced 0 deprecations. However, there is one bugfix relevant to deprecations. In Ember 3.24, various string methods added to the `String.prototype` were deprecated for removal in Ember 4.0. `htmlSafe` (the version available via string prototype) was supposed to be included in those deprecations, however it was missed. This omission can be understood as a bug.
-
-For more details on changes in Ember.js 3.28, please review the [Ember.js 3.28.0 release page](https://github.com/emberjs/ember.js/releases/tag/v3.28.0).
+In Ember 3.24, various string methods added to the `String.prototype` were deprecated for removal in Ember 4.0. `htmlSafe` (the version available via string prototype) was supposed to be included in those deprecations, however it was overlooked. This omission is corrected in 3.28.
 
 ---
 
@@ -62,6 +56,27 @@ Ember Data 3.28 introduced 12 bug fixes and some internal refactors. For the ful
 
 Ember CLI is the command line interface for managing and packaging Ember.js applications.
 
+### Changes in Ember CLI 3.28
+
+#### Drop Node 10 support
+
+Ember CLI 3.28 drops support for Node 10. Node 10 became end of life (it no longer received security updates) as of April 2021.
+
+##### Introducing `ember-addon.projectRoot`
+
+This new configuration option allows you to run `ember s` from outside of a project's root directory. For example, if you're using yarn workspace or a monorepo and want to support running `ember serve` from the root of the repo, update the top-level `package.json` to include the following config:
+
+```json
+{
+  "ember-addon": {
+    "projectRoot": "./packages/path-to-ember-project"
+  }
+}
+```
+
+For more details on the changes in Ember CLI 3.28 and detailed upgrade
+instructions, please review the [Ember CLI 3.28.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.28.0).
+
 ### Upgrading Ember CLI
 
 You may upgrade Ember CLI using the `ember-cli-update` project:
@@ -73,39 +88,6 @@ npx ember-cli-update
 This utility will help you to update your app or addon to the latest Ember CLI version. You will probably encounter merge conflicts, in which the default behavior is to let you resolve conflicts on your own. For more information on the `ember-cli-update` project, see [the GitHub README](https://github.com/ember-cli/ember-cli-update).
 
 While it is recommended to keep Ember CLI versions in sync with Ember and Ember Data, this is not required. After updating ember-cli, you can keep your current version(s) of Ember or Ember Data by editing `package.json` to revert the changes to the lines containing `ember-source` and `ember-data`.
-
-### Changes in Ember CLI 3.28
-
-#### Drop Node 10 support
-
-Ember CLI 3.28 drops support for Node 10. Node 10 became end of life (it no longer received security updates) as of April 2021.
-
-#### Bug Fixes
-
-Ember CLI 3.28 introduced 0 bug fixes.
-
-#### Features
-
-Ember CLI 3.28 introduced 1 feature.
-
-##### `ember-addon.projectRoot`
-
-This config allows you to have a nested project, supporting running `ember s` from outside of the project's directory. For example, if you're using yarn workspace or a monorepo and still want to allow `ember serve` from the root of the repo, update the top-level `package.json` to include the following config:
-
-```json
-{
-  "ember-addon": {
-    "projectRoot": "./packages/path-to-ember-project"
-  }
-}
-```
-
-#### Deprecations
-
-Ember CLI 3.28 introduced 0 deprecations.
-
-For more details on the changes in Ember CLI 3.28 and detailed upgrade
-instructions, please review the [Ember CLI 3.28.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.28.0).
 
 ## Thank You!
 

--- a/content/ember-3-28-released.md
+++ b/content/ember-3-28-released.md
@@ -46,6 +46,16 @@ Ember Data is the official data persistence library for Ember.js applications. T
 
 ### Changes in Ember Data 3.28
 
+#### Improvements to relationship materialization & unloading performance
+
+A number of performance improvements ship in Ember Data 3.28, including
+significant improvements to relationship materialization and unloading performance
+via [emberjs/data#7491](https://github.com/emberjs/data/pull/7491) and
+[emberjs/data#7493](https://github.com/emberjs/data/pull/7493). Especially when
+loading large sets of data, the performance improvements should be notable.
+
+See the PRs linked above and [changelog](https://github.com/emberjs/data/blob/v3.28.3/CHANGELOG.md#release-3280-aug-20-2021) for further notes on performance improvements.
+
 #### Unload records from the store when calling `destroyRecord`
 
 `destroyRecord` would previously leave the deleted record in the store. This
@@ -107,7 +117,7 @@ For further details on these new capabilities, refer to:
 
 #### Bug Fixes
 
-Ember Data 3.28 introduced 12 bug fixes and some internal refactors. For the full set of changes, see the [CHANGELOG.md](https://github.com/emberjs/data/blob/v3.28.0/CHANGELOG.md#release-3280-aug-20-2021).
+Ember Data 3.28 introduced 12 bug fixes and some internal refactors. For the full set of changes, see the [CHANGELOG.md](https://github.com/emberjs/data/blob/v3.28.3/CHANGELOG.md#release-3280-aug-20-2021).
 
 ---
 

--- a/content/ember-3-28-released.md
+++ b/content/ember-3-28-released.md
@@ -115,6 +115,10 @@ For further details on these new capabilities, refer to:
 - [RFC #463: Record State on RecordData](https://github.com/emberjs/rfcs/blob/master/text/0463-record-data-state.md)
 - [RFC #463: RecordData Errors](https://github.com/emberjs/rfcs/blob/master/text/0465-record-data-errors.md)
 
+Much of this API surface is already used by the
+[ember-m3](https://github.com/hjdivad/ember-m3) project, which provides an
+alternative model class for Ember Data.
+
 #### Bug Fixes
 
 Ember Data 3.28 introduced 12 bug fixes and some internal refactors. For the full set of changes, see the [CHANGELOG.md](https://github.com/emberjs/data/blob/v3.28.3/CHANGELOG.md#release-3280-aug-20-2021).

--- a/content/ember-3-28-released.md
+++ b/content/ember-3-28-released.md
@@ -32,7 +32,7 @@ Ember.js is the core framework for building ambitious web applications.
 
 ### Changes in Ember.js 3.28
 
-Ember.js 3.28 is an incremental, backwards compatible release of Ember with bug fixes, performance improvements, and minor deprecations. 3.28 is light on changes because we want the final release of the 2.x cycle to be as stable and battle-tested as possible, so it does not have new features.
+Ember.js 3.28 is an incremental, backwards compatible release of Ember with bug fixes, performance improvements, and minor deprecations. 3.28 is light on changes because we want the final release of the 3.x cycle to be as stable and battle-tested as possible, so it does not have new features.
 
 #### Bug Fixes
 

--- a/content/ember-3-28-released.md
+++ b/content/ember-3-28-released.md
@@ -2,8 +2,8 @@
 title: Ember 3.28 and 4.0 Beta Released
 authors:
   - matthew-beale
-  - isaac-lee
   - jen-weber
+  - isaac-lee
 date: 2021-09-07T00:00:00.000Z
 tags:
   - releases
@@ -12,9 +12,9 @@ tags:
 ---
 
 After 3.5 years and 28 minor releases, Ember 3.28 marks the end of the project's 3.x series.
-To ensure a smooth upgrade path going into the 4.x series, 3.28 has been declared an LTS (Long Term Support) candidate. In six weeks
-the latest patch version of 3.28 will be promoted to be the latest LTS release,
-replacing 3.24-LTS.
+To ensure a smooth upgrade path going into the 4.x series, 3.28 has been declared an LTS (Long Term Support) candidate. In six weeks,
+the latest patch version of 3.28 will be promoted to be the latest LTS release
+and replace 3.24-LTS.
 
 **We're also announcing the start of the Ember 4.0 beta cycle for all sub-projects.** Following the process set in previous major versions, Ember 4.0's beta introduces no new features. Instead, it removes support for deprecated public APIs. We encourage our community (especially addon authors) to help test beta builds and report any bugs before they are published as a stable release in six weeks' time. We also encourage everyone to help maintainers resolve deprecations in their favorite addons. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
 
@@ -42,29 +42,29 @@ In Ember 3.24, various string methods added to the `String.prototype` were depre
 
 ## Ember Data
 
-Ember Data is the official data persistence library for Ember.js applications. The changes introduced in Ember Data 2.18 mostly focus on bug fixes and refactors in preparation for 4.0.
+Ember Data is the official data persistence library for Ember.js applications. The changes introduced in Ember Data 3.28 focus on bug fixes and refactors in preparation for 4.0.
 
 ### Changes in Ember Data 3.28
 
 #### Improvements to relationship materialization & unloading performance
 
-A number of performance improvements ship in Ember Data 3.28, including
+A number of performance improvements were shipped in Ember Data 3.28, including
 significant improvements to relationship materialization and unloading performance
 via [emberjs/data#7491](https://github.com/emberjs/data/pull/7491) and
-[emberjs/data#7493](https://github.com/emberjs/data/pull/7493). Especially when
-loading large sets of data, the performance improvements should be notable.
+[emberjs/data#7493](https://github.com/emberjs/data/pull/7493). In particular,
+the performance improvements should be notable when loading large sets of data.
 
 See the PRs linked above and [changelog](https://github.com/emberjs/data/blob/v3.28.3/CHANGELOG.md#release-3280-aug-20-2021) for further notes on performance improvements.
 
 #### Unload records from the store when calling `destroyRecord`
 
 `destroyRecord` would previously leave the deleted record in the store. This
-could cause issues if ids were re-used, or lead to extra filtering steps to
-confirm destroyed content was not in an array of models.
+could cause issues if IDs were re-used, or could require extra filtering to
+confirm that destroyed content was not in an array of models.
 
 3.28 will unload records from the store when `destroyRecord` is called. For more
-details see [emberjs/data#7258](https://github.com/emberjs/data/pull/7258) and
-the issues cross-linked from that PR.
+details, see [emberjs/data#7258](https://github.com/emberjs/data/pull/7258) and
+the GitHub issues mentioned in the PR.
 
 #### Custom Model Classes
 
@@ -90,23 +90,23 @@ export default class PersonModel extends Model {
 }
 ```
 
-Ember Data 3.28 introduces the ability to seperate model schema and record instance
-class definitions. This is a low-level capability we expect to be used by addon
-authors as they experiment in at least two areas:
+Ember Data 3.28 introduces the ability to separate model schema and record instance
+class definitions. This is a low-level capability that we expect addon authors
+to use when they experiment in these areas (possibly others):
 
 First, forcing the definition (statically or at runtime) of a distinct class for
 every model can cause performance issues. Large applications may have hundreds
-of models. If most or all of those models do not require unique classes, we're
-generating unnecessary memory load and asking more of the JIT's type system than
-may be necassary. In the extreme case, it may be possible for all record
+of models. If most or all of these models do not require unique classes, we're
+generating more memory load and asking more of the JIT's type system than
+they may be necessary. In the extreme case, it may be possible for all record
 instances in an application to share a single root class.
 
 Second, the current Ember Data schema definition API forces definitions to be authored in
 JavaScript. Removing that limitation allows us to experiment with more optimal
 or powerful ways to encode schema (such as JSON). These alternatives may perform
 better (in payload size, or in parse/eval), may better support generation and
-synchornization with API typing systems, and better support static analysis
-(for example with TypeScript).
+synchronization with API typing systems, and better support static analysis
+(for example, with TypeScript).
 
 For further details on these new capabilities, refer to:
 
@@ -129,11 +129,11 @@ Ember CLI is the command line interface for managing and packaging Ember.js appl
 
 #### Drop Node 10 support
 
-Ember CLI 3.28 drops support for Node 10. Node 10 became end of life (it no longer received security updates) as of April 2021.
+Ember CLI 3.28 drops support for Node 10. Node 10 became end of life (it no longer receives security updates) in April 2021.
 
-##### Introducing `ember-addon.projectRoot`
+#### Introducing `ember-addon.projectRoot`
 
-This new configuration option allows you to run `ember s` from outside of a project's root directory. For example, if you're using yarn workspace or a monorepo and want to support running `ember serve` from the root of the repo, update the top-level `package.json` to include the following config:
+This new configuration option allows you to run `ember serve` from outside of a project's root directory. For example, if you're using yarn workspace or a monorepo and want to support running `ember serve` from the root of the repo, update the top-level `package.json` to include the following config:
 
 ```json
 {

--- a/content/ember-3-28-released.md
+++ b/content/ember-3-28-released.md
@@ -46,6 +46,55 @@ Ember Data is the official data persistence library for Ember.js applications. T
 
 ### Changes in Ember Data 3.28
 
+#### Custom Model Classes
+
+Used conventionally, Ember Data blends the definition of a model's schema and
+record API into a single JavaScript class. For example:
+
+```js
+import Model from '@ember-data/model';
+
+export default class PersonModel extends Model {
+  /*
+   * Define a schema
+   */
+  @attr('string') firstName;
+  @attr('string') lastName;
+
+  /*
+   * Define an API on the record instance
+   */
+  get fullName() {
+    return `${this.firstName} ${this.lastName}`;
+  }
+}
+```
+
+Ember Data 3.28 introduces the ability to seperate model schema and record instance
+class definitions. This is a low-level capability we expect to be used by addon
+authors as they experiment in at least two areas:
+
+First, forcing the definition (statically or at runtime) of a distinct class for
+every model can cause performance issues. Large applications may have hundreds
+of models. If most or all of those models do not require unique classes, we're
+generating unnecessary memory load and asking more of the JIT's type system than
+may be necassary. In the extreme case, it may be possible for all record
+instances in an application to share a single root class.
+
+Second, the current Ember Data schema definition API forces definitions to be authored in
+JavaScript. Removing that limitation allows us to experiment with more optimal
+or powerful ways to encode schema (such as JSON). These alternatives may perform
+better (in payload size, or in parse/eval), may better support generation and
+synchornization with API typing systems, and better support static analysis
+(for example with TypeScript).
+
+For further details on these new capabilities, refer to:
+
+- [RFC #487: Custom Model Class](https://github.com/emberjs/rfcs/blob/master/text/0487-custom-model-classes.md)
+- [RFC #466: Request State Service](https://github.com/emberjs/rfcs/blob/master/text/0466-request-state-service.md)
+- [RFC #463: Record State on RecordData](https://github.com/emberjs/rfcs/blob/master/text/0463-record-data-state.md)
+- [RFC #463: RecordData Errors](https://github.com/emberjs/rfcs/blob/master/text/0465-record-data-errors.md)
+
 #### Bug Fixes
 
 Ember Data 3.28 introduced 12 bug fixes and some internal refactors. For the full set of changes, see the [CHANGELOG.md](https://github.com/emberjs/data/blob/v3.28.0/CHANGELOG.md#release-3280-aug-20-2021).

--- a/content/ember-3-28-released.md
+++ b/content/ember-3-28-released.md
@@ -46,6 +46,16 @@ Ember Data is the official data persistence library for Ember.js applications. T
 
 ### Changes in Ember Data 3.28
 
+#### Unload records from the store when calling `destroyRecord`
+
+`destroyRecord` would previously leave the deleted record in the store. This
+could cause issues if ids were re-used, or lead to extra filtering steps to
+confirm destroyed content was not in an array of models.
+
+3.28 will unload records from the store when `destroyRecord` is called. For more
+details see [emberjs/data#7258](https://github.com/emberjs/data/pull/7258) and
+the issues cross-linked from that PR.
+
 #### Custom Model Classes
 
 Used conventionally, Ember Data blends the definition of a model's schema and

--- a/content/ember-3-28-released.md
+++ b/content/ember-3-28-released.md
@@ -1,0 +1,116 @@
+---
+title: Ember 3.28 Released
+authors:
+  - the-crowd # replace with real authors from the author folder (add yourself if you're not there)
+date: 2021-08-31T00:00:00.000Z
+tags:
+  - releases
+  - '2021'
+  - version-3-x
+---
+
+Today the Ember project is releasing version 3.28 of Ember.js, Ember Data, and Ember CLI. This release of Ember.js is an LTS (Long Term Support) candidate. LTS candidates prioritize stability over the addition of new features, and have an extended support schedule.
+
+This release kicks off the 4.0 beta cycle for all sub-projects. We encourage our community (especially addon authors) to help test these beta builds and report any bugs before they are published as a final release in six weeks' time. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
+
+You can read more about our general release process here:
+
+- [Release Dashboard](http://emberjs.com/releases/)
+- [The Ember Release Cycle](https://blog.emberjs.com/new-ember-release-process/)
+- [The Ember Project](https://blog.emberjs.com/ember-project-at-2-0/)
+- [Ember LTS Releases](https://blog.emberjs.com/announcing-embers-first-lts/)
+
+---
+
+## Ember.js
+
+Ember.js is the core framework for building ambitious web applications.
+
+### Changes in Ember.js 3.28
+
+Ember.js 3.28 is an incremental, backwards compatible release of Ember with bug fixes, performance improvements, and minor deprecations.
+
+#### Bug Fixes
+
+Ember.js 3.28 introduced 0 bug fixes.
+
+#### Features
+
+Ember.js 3.28 introduced 2 features.
+
+1. Feature description
+2. Feature description
+
+#### Deprecations
+
+Ember.js 3.28 introduced 0 deprecations.
+
+<!-- Block start: If there were no deprecations, remove this block -->
+Deprecations are added to Ember.js when an API will be removed at a later date. Each deprecation has an entry in the deprecation guide describing the migration path to a more stable API. Deprecated public APIs are not removed until a major release of the framework.
+
+Consider using the [ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow) addon if you would like to upgrade your application without immediately addressing deprecations.
+<!-- Block end -->
+
+For more details on changes in Ember.js 3.28, please review the [Ember.js 3.28.0 release page](https://github.com/emberjs/ember.js/releases/tag/v3.28.0).
+
+---
+
+## Ember Data
+
+Ember Data is the official data persistence library for Ember.js applications.
+
+### Changes in Ember Data 3.28
+
+#### Bug Fixes
+
+Ember Data 3.28 introduced 0 bug fixes.
+
+#### Features
+
+Ember Data 3.28 introduced 0 features.
+
+#### Deprecations
+
+Ember Data 3.28 introduced 0 deprecations.
+
+For more details on changes in Ember Data 3.28, please review the
+[Ember Data 3.28.0 release page](https://github.com/emberjs/data/releases/tag/v3.28.0).
+
+---
+
+## Ember CLI
+
+Ember CLI is the command line interface for managing and packaging Ember.js applications.
+
+### Upgrading Ember CLI
+
+You may upgrade Ember CLI using the `ember-cli-update` project:
+
+```bash
+npx ember-cli-update
+```
+
+This utility will help you to update your app or addon to the latest Ember CLI version. You will probably encounter merge conflicts, in which the default behavior is to let you resolve conflicts on your own. For more information on the `ember-cli-update` project, see [the GitHub README](https://github.com/ember-cli/ember-cli-update).
+
+While it is recommended to keep Ember CLI versions in sync with Ember and Ember Data, this is not required. After updating ember-cli, you can keep your current version(s) of Ember or Ember Data by editing `package.json` to revert the changes to the lines containing `ember-source` and `ember-data`.
+
+### Changes in Ember CLI 3.28
+
+#### Bug Fixes
+
+Ember CLI 3.28 introduced 0 bug fixes.
+
+#### Features
+
+Ember CLI 3.28 introduced 0 features.
+
+#### Deprecations
+
+Ember CLI 3.28 introduced 0 deprecations.
+
+For more details on the changes in Ember CLI 3.28 and detailed upgrade
+instructions, please review the [Ember CLI 3.28.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.28.0).
+
+## Thank You!
+
+As a community-driven open-source project with an ambitious scope, each of these releases serves as a reminder that the Ember project would not have been possible without your continued support. We are extremely grateful to our contributors for their efforts.

--- a/content/ember-3-28-released.md
+++ b/content/ember-3-28-released.md
@@ -1,5 +1,5 @@
 ---
-title: Ember 3.28 Released
+title: Ember 3.28 and 4.0 Beta Released
 authors:
   - matthew-beale
   - isaac-lee
@@ -10,16 +10,18 @@ tags:
   - version-3-x
 ---
 
-Today the Ember project is announcing version 3.28 of Ember.js, Ember Data, and Ember CLI. This is a minor version, stable release.
-
-Ember 3.28 is also an LTS (Long Term Support) release candidate. In six weeks
+After 3.5 years and 28 minor releases, Ember 3.28 marks the end of the project's 3.x series.
+To ensure a smooth upgrade path going into the 4.x series, 3.28 has been declared an LTS (Long Term Support) candidate. In six weeks
 the latest patch version of 3.28 will be promoted to be the latest LTS release
 replacing 3.24-LTS.
 
-**We're also announcing the start of the Ember 4.0 beta cycle for all sub-projects.** We encourage our community (especially addon authors) to help test beta builds and report any bugs before they are published as a stable release in six weeks' time. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
+**We're also announcing the start of the Ember 4.0 beta cycle for all sub-projects.** Following the process set in previous major versions, Ember 4.0 introduces no new features. Instead, it removes support for deprecated public APIs. We encourage our community (especially addon authors) to help test beta builds and report any bugs before they are published as a stable release in six weeks' time. We also encourage everyone to help maintainers resolve deprecations in their favorite addons. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
 
-You can read more about Ember's plans for 4.0 in [The Road to Ember
-4.0](https://blog.emberjs.com/the-road-to-ember-4-0/)
+Developers who want to prepare for the upcoming 4.0 version of Ember should work to resolve all deprecation warnings in their apps and addons.
+An app or addon with no deprecation warnings should be able to upgrade from Ember 3.28 to 4.0 without making significant changes outside of the
+dependency versions.
+
+You can read more about Ember's plans for 4.0 in [The Road to Ember 4.0](https://blog.emberjs.com/the-road-to-ember-4-0/).
 
 ---
 
@@ -29,30 +31,15 @@ Ember.js is the core framework for building ambitious web applications.
 
 ### Changes in Ember.js 3.28
 
-Ember.js 3.28 is an incremental, backwards compatible release of Ember with bug fixes, performance improvements, and minor deprecations.
+Ember.js 3.28 is an incremental, backwards compatible release of Ember with bug fixes, performance improvements, and minor deprecations. 3.28 is light on changes because we want the final release of the 2.x cycle to be as stable and battle-tested as possible, so it does not have new features.
 
 #### Bug Fixes
 
-Ember.js 3.28 introduced 0 bug fixes.
-
-#### Features
-
-Ember.js 3.28 introduced 2 features.
-
-1. Feature description
-2. Feature description
+Ember.js 3.28 introduced 7 bug fixes. For the full set of changes, see the [Release notes changelog](https://github.com/emberjs/ember.js/releases/tag/v3.28.0).
 
 #### Deprecations
 
-Ember.js 3.28 introduced 0 deprecations.
-
-<!-- Block start: If there were no deprecations, remove this block -->
-
-Deprecations are added to Ember.js when an API will be removed at a later date. Each deprecation has an entry in the deprecation guide describing the migration path to a more stable API. Deprecated public APIs are not removed until a major release of the framework.
-
-Consider using the [ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow) addon if you would like to upgrade your application without immediately addressing deprecations.
-
-<!-- Block end -->
+Ember.js 3.28 introduced 0 deprecations. However, there is one bugfix relevant to deprecations. In Ember 3.24, various string methods added to the `String.prototype` were deprecated for removal in Ember 4.0. `htmlSafe` (the version available via string prototype) was supposed to be included in those deprecations, however it was missed. This omission can be understood as a bug.
 
 For more details on changes in Ember.js 3.28, please review the [Ember.js 3.28.0 release page](https://github.com/emberjs/ember.js/releases/tag/v3.28.0).
 
@@ -60,24 +47,13 @@ For more details on changes in Ember.js 3.28, please review the [Ember.js 3.28.0
 
 ## Ember Data
 
-Ember Data is the official data persistence library for Ember.js applications.
+Ember Data is the official data persistence library for Ember.js applications. The changes introduced in Ember Data 2.18 mostly focus on bug fixes and refactors in preparation for 4.0.
 
 ### Changes in Ember Data 3.28
 
 #### Bug Fixes
 
-Ember Data 3.28 introduced 0 bug fixes.
-
-#### Features
-
-Ember Data 3.28 introduced 0 features.
-
-#### Deprecations
-
-Ember Data 3.28 introduced 0 deprecations.
-
-For more details on changes in Ember Data 3.28, please review the
-[Ember Data 3.28.0 release page](https://github.com/emberjs/data/releases/tag/v3.28.0).
+Ember Data 3.28 introduced 12 bug fixes and some internal refactors. For the full set of changes, see the [CHANGELOG.md](https://github.com/emberjs/data/blob/v3.28.0/CHANGELOG.md#release-3280-aug-20-2021).
 
 ---
 
@@ -99,13 +75,29 @@ While it is recommended to keep Ember CLI versions in sync with Ember and Ember 
 
 ### Changes in Ember CLI 3.28
 
+#### Drop Node 10 support
+
+Ember CLI 3.28 drops support for Node 10. Node 10 became end of life (it no longer received security updates) as of April 2021.
+
 #### Bug Fixes
 
 Ember CLI 3.28 introduced 0 bug fixes.
 
 #### Features
 
-Ember CLI 3.28 introduced 0 features.
+Ember CLI 3.28 introduced 1 feature.
+
+##### `ember-addon.projectRoot`
+
+This config allows you to have a nested project, supporting running `ember s` from outside of the project's directory. For example, if you're using yarn workspace or a monorepo and still want to allow `ember serve` from the root of the repo, update the top-level `package.json` to include the following config:
+
+```json
+{
+  "ember-addon": {
+    "projectRoot": "./packages/path-to-ember-project"
+  }
+}
+```
 
 #### Deprecations
 

--- a/content/ember-3-28-released.md
+++ b/content/ember-3-28-released.md
@@ -1,24 +1,25 @@
 ---
 title: Ember 3.28 Released
 authors:
-  - the-crowd # replace with real authors from the author folder (add yourself if you're not there)
-date: 2021-08-31T00:00:00.000Z
+  - matthew-beale
+  - isaac-lee
+date: 2021-09-02T00:00:00.000Z
 tags:
   - releases
   - '2021'
   - version-3-x
 ---
 
-Today the Ember project is releasing version 3.28 of Ember.js, Ember Data, and Ember CLI. This release of Ember.js is an LTS (Long Term Support) candidate. LTS candidates prioritize stability over the addition of new features, and have an extended support schedule.
+Today the Ember project is announcing version 3.28 of Ember.js, Ember Data, and Ember CLI. This is a minor version, stable release.
 
-This release kicks off the 4.0 beta cycle for all sub-projects. We encourage our community (especially addon authors) to help test these beta builds and report any bugs before they are published as a final release in six weeks' time. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
+Ember 3.28 is also an LTS (Long Term Support) release candidate. In six weeks
+the latest patch version of 3.28 will be promoted to be the latest LTS release
+replacing 3.24-LTS.
 
-You can read more about our general release process here:
+**We're also announcing the start of the Ember 4.0 beta cycle for all sub-projects.** We encourage our community (especially addon authors) to help test beta builds and report any bugs before they are published as a stable release in six weeks' time. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
 
-- [Release Dashboard](http://emberjs.com/releases/)
-- [The Ember Release Cycle](https://blog.emberjs.com/new-ember-release-process/)
-- [The Ember Project](https://blog.emberjs.com/ember-project-at-2-0/)
-- [Ember LTS Releases](https://blog.emberjs.com/announcing-embers-first-lts/)
+You can read more about Ember's plans for 4.0 in [The Road to Ember
+4.0](https://blog.emberjs.com/the-road-to-ember-4-0/)
 
 ---
 
@@ -46,9 +47,11 @@ Ember.js 3.28 introduced 2 features.
 Ember.js 3.28 introduced 0 deprecations.
 
 <!-- Block start: If there were no deprecations, remove this block -->
+
 Deprecations are added to Ember.js when an API will be removed at a later date. Each deprecation has an entry in the deprecation guide describing the migration path to a more stable API. Deprecated public APIs are not removed until a major release of the framework.
 
 Consider using the [ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow) addon if you would like to upgrade your application without immediately addressing deprecations.
+
 <!-- Block end -->
 
 For more details on changes in Ember.js 3.28, please review the [Ember.js 3.28.0 release page](https://github.com/emberjs/ember.js/releases/tag/v3.28.0).


### PR DESCRIPTION
## TODO

### 1. Ember.js

#### Bug Fixes

- [ ] [#19697](https://github.com/emberjs/ember.js/pull/19697) Ensure `deserializeQueryParam` is called for lazy routes
- [x] [#19681](https://github.com/emberjs/ember.js/pull/19681) Restore previous hash behavior
- [x] [#19685](https://github.com/emberjs/ember.js/pull/19685) Fix memory leak in `RouterService`
- [x] [#19690](https://github.com/emberjs/ember.js/pull/19690) Deprecates `String.prototype.htmlSafe` targeting Ember 4.0, as intended by the original deprecation.
- [ ] [#19584](https://github.com/emberjs/ember.js/pull/19584) Ensure hash objects correctly entangle as dependencies
- [ ] [#19491](https://github.com/emberjs/ember.js/pull/19491) Fix `owner.lookup` `owner.register` behavior with singleton: true option
- [x] [#19472](https://github.com/emberjs/ember.js/pull/19472) Prevent transformation of block params called `attrs`

[Changelog](https://github.com/emberjs/ember.js/releases/tag/v3.28.0)


### 2. Ember Data

#### Bug Fixes

- [ ] [#7651](https://github.com/emberjs/data/pull/7651) Return inflight requests for `findRecord` when `CUSTOM_MODEL_CLASS` is on
- [ ] [#7652](https://github.com/emberjs/data/pull/7652) Fix for `CUSTOM_MODEL_CLASS` and deprecate passing non ember data records to `unloadRecord` and `deleteRecord`
- [ ] [#7643](https://github.com/emberjs/data/pull/7643) `@ember-data/model`: Simplify `@cached` transpilation
- [ ] [#7554](https://github.com/emberjs/data/pull/7554) reset previously failed linked async belongs-to now works
- [ ] [#7532](https://github.com/emberjs/data/pull/7532) fix: belongsTo should not attempt load if inverse in payload provided its data
- [ ] [#7550](https://github.com/emberjs/data/pull/7550) fix: add asserts and assert tests for `belongsTo`/`hasMany`/`findRecord` empty responses
- [ ] [#7534](https://github.com/emberjs/data/pull/7534) fix: Ensure meta and links update when fetched relationship is empty or does not include the data key
- [ ] [#7545](https://github.com/emberjs/data/pull/7545) assert when `'content'` is used as a property on a record
- [ ] [#7531](https://github.com/emberjs/data/pull/7531) fix: Closes issue preventing debug adapter removal from prod builds using the ember-data package
- [ ] [#7527](https://github.com/emberjs/data/pull/7527) rollup step should deactivate ember modules polyfill >= 3.27
- [ ] [#7425](https://github.com/emberjs/data/pull/7425) Pass lid from relationship data to get record data
- [ ] [#7448](https://github.com/emberjs/data/pull/7448) `coalesceFindRequests` should work with non native Adapter classes
- [ ] [#7463](https://github.com/emberjs/data/pull/7463) chore: cleanup Implicit relationships
- [ ] [#7453](https://github.com/emberjs/data/pull/7453) chore: burndown of `InternalModel` methods that can be eliminated safely
- [ ] [#7226](https://github.com/emberjs/data/pull/7226) refactor: Native Model
- [ ] [#7470](https://github.com/emberjs/data/pull/7470) chore: convert relationships to use identifiers

#### Features

- [x] [#7258](https://github.com/emberjs/data/pull/7258) feat: record.destroyRecord should also unload the record
- [x] [#7510](https://github.com/emberjs/data/pull/7510) feat: activate all feature flags related to `CUSTOM_MODEL_CLASSES`

[Changelog](https://github.com/emberjs/data/blob/v3.28.0/CHANGELOG.md#release-3280-aug-20-2021)


### 3. Ember CLI

- [ ] [#9505](https://github.com/ember-cli/ember-cli/pull/9505) Pass `realPath` as root rather than the `dirname` for `addonMainPath`
- [x] [#9507](https://github.com/ember-cli/ember-cli/pull/9507) Add a new config, `ember-addon.projectRoot`, to specify the location of the project
- [x] [#9530](https://github.com/ember-cli/ember-cli/pull/9530) Drop Node 10 support
- [ ] [#9487](https://github.com/ember-cli/ember-cli/pull/9487) Add support for creating a single addon instance per bundle root (which enables dramatically reducing the total number of addon instances)
- [ ] [#9524](https://github.com/ember-cli/ember-cli/pull/9524) Update `CONTRIBUTING.md` to reference `cli.emberjs.com`
- [ ] [#9533](https://github.com/ember-cli/ember-cli/pull/9533) Ensure package-info objects are stable when they represent the same addon
- [ ] [#9538](https://github.com/ember-cli/ember-cli/pull/9538) ensure backwards compatibility is maintained with packageRoot and root
- [ ] [#9539](https://github.com/ember-cli/ember-cli/pull/9539) avoid setting root as realPath from the package-info object
- [x] [#9537](https://github.com/ember-cli/ember-cli/pull/9537) Implement LCA host/host addons logic in ember-cli
- [ ] [#9540](https://github.com/ember-cli/ember-cli/pull/9540) Use relative override paths in blueprint ESLint config
- [ ] [#9542](https://github.com/ember-cli/ember-cli/pull/9542) Add validation checks for addon instance bundle caching
- [ ] [#9543](https://github.com/ember-cli/ember-cli/pull/9543) Add ability to specify a custom `ember-addon.perBundleAddonCacheUtil` utility
- [x] [#9562](https://github.com/ember-cli/ember-cli/pull/9562) Update `addon-proxy` to support Embroider
- [ ] [#9565](https://github.com/ember-cli/ember-cli/pull/9565) Drop Node 10 support in blueprint engine spec
- [ ] [#9568](https://github.com/ember-cli/ember-cli/pull/9568) [BUGFIX release] Skip babel for qunit with embroider

[Changelog](https://github.com/ember-cli/ember-cli/releases/tag/v3.28.0)