### PR TITLE
Add Hacktoberfest for issue #191

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 content/the-ember-times-issue* @ember-learn/ember-times-editors
+post-templates/hacktoberfest.md @ember-learn/ember-times-editors

--- a/post-templates/hacktobertfest.md
+++ b/post-templates/hacktobertfest.md
@@ -1,0 +1,7 @@
+Topics:
+
+- [ ] uELS 3.0.4 published to VScode store, see: https://discord.com/channels/480462759797063690/480499624663056390/896699510888226826
+
+Future stories:
+
+- [ ] EmberFest videos, if live in time

--- a/post-templates/hacktobertfest.md
+++ b/post-templates/hacktobertfest.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable-file -->
+
 Topics:
 
 - [ ] uELS 3.0.4 published to VScode store, see: https://discord.com/channels/480462759797063690/480499624663056390/896699510888226826


### PR DESCRIPTION
If we use this instead of the PR description for https://github.com/ember-learn/ember-blog/pull/1047, folks can get Hacktoberfest credit