### PR TITLE
Add run-loop-and-computed-dot-access deprecation note to 3.27 release

### DIFF
--- a/content/ember-3-27-released.md
+++ b/content/ember-3-27-released.md
@@ -215,6 +215,36 @@ See [the deprecation
 guide](https://deprecations.emberjs.com/v3.x/#toc_ember-global) and [RFC 706](https://github.com/emberjs/rfcs/blob/master/text/0706-deprecate-ember-global.md)
 for more details and transition paths for other use cases.
 
+#### Deprecate run loop and computed dot access
+
+Using `.` to access computed or run loop functions has been deprecated, such as `computed.filter`.
+Instead, import the value directly from the module:
+
+```js
+// Bad, deprecated
+import EmberObject, { computed } from '@ember/object';
+
+const Tomster = EmberObject.extend({
+  readyForCamp: computed.and('hasTent', 'hasBackpack'),
+  readyForHike: computed.and('hasWalkingStick', 'hasBackpack')
+})
+```
+
+```js
+// Good
+import EmberObject from '@ember/object';
+import { and } from '@ember/object/computed';
+
+class Tomster extends EmberObject {
+  @and('hasTent', 'hasBackpack') readyForCamp;
+  @and('hasWalkingStick', 'hasBackpack') readyForHike;
+}
+```
+
+Support for `.` to access computed or run loop functions will be removed in Ember 4.0.
+
+See [the deprecation guide](https://deprecations.emberjs.com/v3.x/#toc_deprecated-run-loop-and-computed-dot-access).
+
 ### Further Information On Upgrade Timelines
 
 For application maintainers who want to upgrade apps to Ember.js 4.0 on its release date, the list of


### PR DESCRIPTION
<!--- Make sure to add a descriptive title in the field above! E.g. "Fixes the header title color on the homepage"  -->

<!-- ## Ember Times review template -->
<!--- Feel free to delete this section if not an Ember Times PR! -->

- [ ] Add your name to top and bottom
- [ ] Put emoji in writeup title
- [ ] Add a short blurb (could be the title) to the beginning
- [ ] Link to external article/repo/etc in paragraph/body text, not just the writeup title (link in writeup title is optional now)
- [ ] Add the contributor in the post in format "FirstName LastName (@githubUserName)" linked to their GitHub account
- [ ] Check that all links work

## What it does
Adds missing `run-loop-and-computed-dot-access` deprecation note to 3.27 release as it's not listed neither in blog post nor release notes in https://github.com/emberjs/ember.js/releases/tag/v3.27.0.

It was actually was introduced in this PR https://github.com/emberjs/ember.js/pull/19463/files which was par of "Add deprecation for the Ember Global per RFC #706" changes.
<!--- Tell us what this fix does in a few sentences. E.g. "This updates the header title's font color to Ember Orange." -->

## Related Issue(s)
* https://github.com/emberjs/ember.js/pull/19463
<!--- Please provide the issue(s) to which this pull request relates to or which issue it closes. E.g. "Closes #1234" -->

<!-- ## Sources -->
<!-- Optional. If applicable be sure to add any screenshots or screen recordings of your work for your reviewers here -->
