### PR TITLE
fix the canonical declaration of re-posted content

### DIFF
--- a/content/coming-soon-in-ember-octane-part-1.md
+++ b/content/coming-soon-in-ember-octane-part-1.md
@@ -3,6 +3,7 @@ title: 'Coming Soon in Ember Octane - Part 1: Native Classes'
 authors:
   - chris-garrett
 date: 2019-02-11T00:00:00.000Z
+canonical: https://www.pzuraq.com/coming-soon-in-ember-octane-part-1-native-classes/
 tags:
   - '2019'
   - ember-octane

--- a/content/coming-soon-in-ember-octane-part-2.md
+++ b/content/coming-soon-in-ember-octane-part-2.md
@@ -3,6 +3,7 @@ title: 'Coming Soon in Ember Octane - Part 2: Angle Brackets & Named Arguments'
 authors:
   - chris-garrett
 date: 2019-02-19T00:00:00.000Z
+canonical: https://www.pzuraq.com/coming-soon-in-ember-octane-part-2-angle-brackets-and-named-arguments/
 tags:
   - '2019'
   - ember-octane

--- a/content/coming-soon-in-ember-octane-part-3.md
+++ b/content/coming-soon-in-ember-octane-part-3.md
@@ -3,6 +3,7 @@ title: 'Coming Soon in Ember Octane - Part 3: Tracked Properties'
 authors:
   - chris-garrett
 date: 2019-02-26T00:00:00.000Z
+canonical: https://www.pzuraq.com/coming-soon-in-ember-octane-part-3-tracked-properties/
 tags:
   - '2019'
   - ember-octane

--- a/content/coming-soon-in-ember-octane-part-4.md
+++ b/content/coming-soon-in-ember-octane-part-4.md
@@ -3,6 +3,7 @@ title: 'Coming Soon in Ember Octane - Part 4: Modifiers'
 authors:
   - chris-garrett
 date: 2019-03-06T00:00:00.000Z
+canonical: https://www.pzuraq.com/coming-soon-in-ember-octane-part-4-modifiers/
 tags:
   - '2019'
   - ember-octane

--- a/content/coming-soon-in-ember-octane-part-5.md
+++ b/content/coming-soon-in-ember-octane-part-5.md
@@ -3,6 +3,7 @@ title: 'Coming Soon in Ember Octane - Part 5: Glimmer Components'
 authors:
   - chris-garrett
 date: 2019-03-14T00:00:00.000Z
+canonical: https://www.pzuraq.com/coming-soon-in-ember-octane-part-5-glimmer-components/
 tags:
   - '2019'
   - ember-octane

--- a/content/emberjs-native-class-update-2019-edition.md
+++ b/content/emberjs-native-class-update-2019-edition.md
@@ -3,6 +3,7 @@ title: Ember.js Native Class Update - 2019 Edition
 authors:
   - chris-garrett
 date: 2019-01-26T00:00:00.000Z
+canonical: https://www.pzuraq.com/emberjs-native-class-update-2019-edition/
 tags:
   - '2019'
   - native-classes
@@ -550,4 +551,3 @@ Generally, derived state like this is handled better by getters/setters, so this
 <!--alex enable just easy-->
 
 And that's all folks! If you have more questions, join the [Ember Discord](https://www.emberjs.com/community/) and ask away, the `#e-decorators`, `#e-typescript`, `#st-native-classes`, and `#st-octane` channels are all great places to get some advice. Thanks for reading!
-


### PR DESCRIPTION
This is something that we can now do since we're using empress-blog, properly designate the canonical version of a post that has been re-posted to the Ember blog 🎉 

This is a very important thing for SEO so that both sides aren't dinged for "duplicate content" 👍 If you want to learn more about duplicate content you can read this [SEO moz article](https://moz.com/learn/seo/duplicate-content#:~:text=Duplicate%20content%20is%20content%20that,you've%20got%20duplicate%20content.)

**Note:** if you want to test this you can use "view source" on the pages that have changed and verify that the canonical reference has been updated correctly 👍 

https://deploy-preview-1157--ember-blog.netlify.app/coming-soon-in-ember-octane-part-1/

vs 

https://blog.emberjs.com/coming-soon-in-ember-octane-part-1/