### PR TITLE
always serve the index.html on netlify

### DIFF
--- a/.netlifyredirects
+++ b/.netlifyredirects
@@ -354,3 +354,5 @@
 /2020/12/18/the-ember-times-issue-170.html /the-ember-times-issue-170/ 301
 
 /author/anne-greeth-van-herwijnen /author/anne-greeth-schot-van-herwijnen 301
+
+/*    /index.html   200


### PR DESCRIPTION
It turns out that going directly to https://blog.emberjs.com/page/1 doesn't work 🤔 this is because we don't have a fallback HTML for netlify

This PR fixes that.

To test: 

- load the netlify preview for this PR
- scroll to the bottom and click "older articles"
- refresh

if it shows you the 404 page from netlify then this didn't work 