### PR TITLE
Add note about the 4.8 LTS promotion to the 4.9 blog post

### DIFF
--- a/content/ember-4-9-released.md
+++ b/content/ember-4-9-released.md
@@ -11,6 +11,11 @@ tags:
 
 Today the Ember project is releasing version 4.9 of Ember.js, Ember Data, and Ember CLI.
 
+Version 4.8 of Ember is now promoted to LTS (Long Term Support).
+An LTS version of Ember continues to receive security updates for 9 release cycles (54 weeks) and bugfixes for 6 cycles (36 weeks).
+LTS releases typically occur every four minor versions.
+The previous LTS version of Ember was 4.4.
+
 This release kicks off the 4.10 beta cycle for all sub-projects. We encourage our community (especially addon authors) to help test these beta builds and report any bugs before they are published as a final release in six weeks' time. The [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to continuously test your projects against the latest Ember releases.
 
 You can read more about our general release process here:


### PR DESCRIPTION
## What it does
This adds a note to the 4.9 release post about the promotion of 4.8 to an LTS release, similar to how it was done in other blog posts.

