### PR TITLE
Announced ember-codemod-v1-to-v2 in The Ember Times

### DIFF
--- a/content/the-ember-times-issue-205.md
+++ b/content/the-ember-times-issue-205.md
@@ -67,7 +67,7 @@ Ember 4.0 has been around for a bit now and we would love to know what is keepin
 
 ## [📦 We need you for TypeScript support!](https://github.com/emberjs/ember.js/issues/20162 )
 
-Want to help get Ember’s official TS support out the door? [RFC 800](https://rfcs.emberjs.com/id/0800-ts-adoption-plan) describes the Typescript adoption plan and you can [sign up](https://github.com/emberjs/ember.js/issues/20162) to help with issues all across our codebase! You can always check the [`#topic-typesscript` channel](https://discord.com/channels/480462759797063690/484421406659182603) on our [Discord server](https://discord.gg/emberjs).
+Want to help get Ember’s official TS support out the door? [RFC 800](https://rfcs.emberjs.com/id/0800-ts-adoption-plan) describes the Typescript adoption plan and you can [sign up](https://github.com/emberjs/ember.js/issues/20162) to help with issues all across our codebase! You can always check the [`#topic-typescript` channel](https://discord.com/channels/480462759797063690/484421406659182603) on our [Discord server](https://discord.gg/emberjs).
 
 ---
 

--- a/content/the-ember-times-issue-205.md
+++ b/content/the-ember-times-issue-205.md
@@ -5,6 +5,7 @@ authors:
   - bryan-mishkin
   - anne-greeth-schot-van-herwijnen
   - chris-ng
+  - isaac-lee
 date: 2022-11-20T00:00:00.000Z
 tags:
   - newsletter
@@ -13,7 +14,7 @@ tags:
 
 👋 Emberistas! 🐹
 
-ember-template-lint 5.0 released 🧹, EmberConf News 🎤, new addons ✨, Ember 4.0+ upgrade survey 🐹, call for support with TS support in Ember 📦, updated addons 📬, Wacky Tricks We Use in Publishing TypeScript Types ▶️,
+ember-template-lint 5.0 released 🧹, EmberConf News 🎤, new addons ✨, Ember 4.0+ upgrade survey 🐹, call for support with TS support in Ember 📦, updated addons 📬, Wacky Tricks We Use in Publishing TypeScript Types ▶️, a new codemod to migrate addons to v2 format 📣
 
 
 <SOME-INTRO-HERE-TO-KEEP-THEM-SUBSCRIBERS-READING>
@@ -93,6 +94,20 @@ Do you want to contribute to help get Ember’s [official TypeScript support](ht
 
 ---
 
+## [📣 A new codemod to migrate addons to v2 format](https://github.com/ijlee2/ember-codemod-v1-to-v2)
+
+With one command, you can get started with migrating Ember addons to v2 format:
+
+```sh
+npx ember-codemod-v1-to-v2
+```
+
+[ember-codemod-v1-to-v2](https://github.com/ijlee2/ember-codemod-v1-to-v2) helps you meet the latest standards set by [@embroider/addon-blueprint](https://github.com/embroider-build/addon-blueprint). The codemod takes care of moving files and updating references to the moved files, while you remain in charge of re-configuring the packages.
+
+[Isaac Lee (@ijlee2)](https://github.com/ijlee2) hopes that `ember-codemod-v1-to-v2`, along with [ember-addon-migrator](https://github.com/NullVoxPopuli/ember-addon-migrator), can help you push Embroider forward. Check out [ember-container-query](https://github.com/ijlee2/ember-container-query/pull/151) for a real-life example.
+
+---
+
 ## [👏 Contributors' corner](https://guides.emberjs.com/release/contributing/repositories/)
 
 <p>This week we'd like to thank our siblings for their contributions to Ember and related repositories! 💖</p>
@@ -119,4 +134,4 @@ That's another wrap! ✨
 
 Be kind,
 
-Jared Galanis, Bryan Mishkin, Anne-Greeth Schot-van Herwijnen, Chris Ng, and the Learning Team
+Jared Galanis, Bryan Mishkin, Anne-Greeth Schot-van Herwijnen, Chris Ng, Isaac Lee and the Learning Team


### PR DESCRIPTION
<!--- Make sure to add a descriptive title in the field above! E.g. "Fixes the header title color on the homepage"  -->

## Ember Times review template
<!--- Feel free to delete this section if not an Ember Times PR! -->

- [x] Add your name to top and bottom
- [x] Put emoji in writeup title
- [x] Add a short blurb (could be the title) to the beginning
- [x] Link to external article/repo/etc in paragraph/body text, not just the writeup title (link in writeup title is optional now)
- [x] Add the contributor in the post in format "FirstName LastName (@githubUserName)" linked to their GitHub account
- [x] Check that all links work

## What it does
<!--- Tell us what this fix does in a few sentences. E.g. "This updates the header title's font color to Ember Orange." -->

I announced a new codemod, `ember-codemod-v1-to-v2`, to help people migrate their addons to v2 addon format.

## Related Issue(s)
<!--- Please provide the issue(s) to which this pull request relates to or which issue it closes. E.g. "Closes #1234" -->

## Sources
<!-- Optional. If applicable be sure to add any screenshots or screen recordings of your work for your reviewers here -->
