### PR TITLE
Fix YAML front matter syntax for tag 2024

### DIFF
--- a/tag/2024.md
+++ b/tag/2024.md
@@ -1,3 +1,4 @@
+---
 name: 2024
 image:
 imageMeta:


### PR DESCRIPTION
## What it does
This PR fixed to show "2024" tag in "By Year" section on sidebar.
The broken syntax won't have display text.

### Before
![image](https://github.com/user-attachments/assets/f47969d4-898f-4109-a741-6b517ce5f760)

## After
<img width="254" alt="image" src="https://github.com/user-attachments/assets/ffddacfc-8d1e-4203-a52c-eca0049abedd">

