### PR TITLE
Updating security release blog post with new backport i info

### DIFF
--- a/content/ember-4-8-1-released.md
+++ b/content/ember-4-8-1-released.md
@@ -10,6 +10,7 @@ tags:
 
 ---
 
+*Updates 2026-01-30: This security fix was also backported to 2.18.3 so that legacy apps on the 2.x major series can also benefit. No CVE number was ever issued to us for this issue.*
 
 Today we are releasing Ember.js 3.24.7, 3.28.10, 4.4.4, 4.8.1, and 4.9.0-beta.3 to patch a security vulnerability.  *A CVE number is pending and this post will be updated to include it once it's been issued.*
 


### PR DESCRIPTION
There's a new patch of a very old release available (2.18.3) thanks to an enterprise client who funded work to backport a security fix for some of their legacy apps.

This updates the release blog post to include 2.18.3 on the list of releases that have been patched.

<!--- Make sure to add a descriptive title in the field above! E.g. "Fixes the header title color on the homepage"  -->

## Ember Times review template
<!--- Feel free to delete this section if not an Ember Times PR! -->

- [ ] Add your name to top and bottom
- [ ] Put emoji in writeup title
- [ ] Add a short blurb (could be the title) to the beginning
- [ ] Link to external article/repo/etc in paragraph/body text, not just the writeup title (link in writeup title is optional now)
- [ ] Add the contributor in the post in format "FirstName LastName (@githubUserName)" linked to their GitHub account
- [ ] Check that all links work

## What it does
<!--- Tell us what this fix does in a few sentences. E.g. "This updates the header title's font color to Ember Orange." -->

## Related Issue(s)
<!--- Please provide the issue(s) to which this pull request relates to or which issue it closes. E.g. "Closes #1234" -->

## Sources
<!-- Optional. If applicable be sure to add any screenshots or screen recordings of your work for your reviewers here -->
