### PR TITLE
Add ember-showdown-shiki languages configuration

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -28,6 +28,18 @@ module.exports = function (environment) {
       prefixHeaderId: 'toc_',
     },
 
+    'ember-showdown-shiki': {
+      languages: [
+        'javascript',
+        'typescript',
+        'handlebars',
+        'glimmer-ts',
+        'glimmer-js',
+        'json',
+        'css',
+      ],
+    },
+
     blog: {
       title: 'Ember.js Blog',
       description: 'Official Blog for the Ember.js Open Source Project',


### PR DESCRIPTION
Only load the languages we need instead of the 200+ languages shiki supports.

| Before | After |
-------|--------
|<img width="837" height="416" alt="image" src="https://github.com/user-attachments/assets/9e82e3f6-f684-4b84-abdf-1c756d1da342" />| <img width="743" height="410" alt="image" src="https://github.com/user-attachments/assets/35ca7429-6c83-4077-a937-6a4741ef89be" /> |